### PR TITLE
feat: add standardized error handling and recovery contract

### DIFF
--- a/stellar-insured-contracts/Cargo.toml
+++ b/stellar-insured-contracts/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts",
     "contracts/authorization",
     "contracts/shared",
+    "contracts/error-handling",
     "contracts/invariants",
     "contracts/policy",
     "contracts/claims",

--- a/stellar-insured-contracts/contracts/error_handling/Cargo.toml
+++ b/stellar-insured-contracts/contracts/error_handling/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "error_handling"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "20.0.0" }
+
+[dev-dependencies]
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/stellar-insured-contracts/contracts/error_handling/src/codes.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/codes.rs
@@ -1,0 +1,224 @@
+#![no_std]
+
+use soroban_sdk::contracterror;
+
+/// Unified error codes shared across all insurance platform contracts.
+///
+/// Ranges:
+///   1–99    Auth & Access
+///   100–199 Policy
+///   200–299 Claims
+///   300–399 Payments & Premiums
+///   400–499 KYC / Compliance
+///   500–599 Data / Storage
+///   600–699 Oracle / External
+///   700–799 System / Config
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum InsuranceError {
+    // ── Auth & Access (1–99) ─────────────────────────────────────────────────
+    /// Caller has not been granted any role on this contract
+    Unauthorized = 1,
+    /// Caller's role does not permit this specific action
+    InsufficientPermissions = 2,
+    /// Auth token or session has expired
+    AuthExpired = 3,
+    /// Contract has already been initialized
+    AlreadyInitialized = 4,
+
+    // ── Policy (100–199) ─────────────────────────────────────────────────────
+    /// No policy exists with the provided ID
+    PolicyNotFound = 100,
+    /// Policy is not in a state that allows this action
+    PolicyInvalidState = 101,
+    /// Policy coverage period has ended
+    PolicyExpired = 102,
+    /// Policy has already been cancelled
+    PolicyAlreadyCancelled = 103,
+    /// Proposed coverage amount is outside allowed limits
+    PolicyCoverageOutOfRange = 104,
+
+    // ── Claims (200–299) ─────────────────────────────────────────────────────
+    /// No claim exists with the provided ID
+    ClaimNotFound = 200,
+    /// Claim amount exceeds the policy's coverage limit
+    ClaimExceedsLimit = 201,
+    /// A claim for this event was already submitted
+    ClaimDuplicate = 202,
+    /// Claim is past the allowed filing deadline
+    ClaimDeadlineExceeded = 203,
+    /// Claim is in a state that does not allow this action
+    ClaimInvalidState = 204,
+    /// Required claim documentation is missing
+    ClaimMissingDocuments = 205,
+
+    // ── Payments & Premiums (300–399) ────────────────────────────────────────
+    /// Provided amount is zero or negative
+    PaymentInvalidAmount = 300,
+    /// Token or asset type is not accepted
+    PaymentUnsupportedAsset = 301,
+    /// Premium payment was not received before the deadline
+    PremiumPaymentOverdue = 302,
+    /// Requested refund amount exceeds what was paid
+    RefundExceedsBalance = 303,
+
+    // ── KYC / Compliance (400–499) ───────────────────────────────────────────
+    /// Policy holder has not completed KYC
+    KycNotVerified = 400,
+    /// KYC has expired and must be renewed
+    KycExpired = 401,
+    /// Submitted KYC documents were rejected
+    KycDocumentRejected = 402,
+    /// Operation blocked due to regulatory restriction
+    ComplianceViolation = 403,
+
+    // ── Data / Storage (500–599) ─────────────────────────────────────────────
+    /// Record could not be found in storage
+    RecordNotFound = 500,
+    /// Provided data fails format or range validation
+    InvalidData = 501,
+    /// Ledger entry TTL has lapsed
+    StorageExpired = 502,
+
+    // ── Oracle / External (600–699) ──────────────────────────────────────────
+    /// Oracle has not published data for this feed
+    OracleDataMissing = 600,
+    /// Oracle data is older than the acceptable staleness window
+    OracleDataStale = 601,
+    /// Cross-contract call returned an unexpected error
+    ExternalCallFailed = 602,
+
+    // ── System / Config (700–799) ────────────────────────────────────────────
+    /// Contract is paused for maintenance or emergency
+    ContractPaused = 700,
+    /// Requested operation is not yet implemented
+    NotImplemented = 701,
+    /// Numerical overflow detected
+    ArithmeticOverflow = 702,
+    /// Value exceeds the maximum allowed
+    LimitExceeded = 703,
+}
+
+impl InsuranceError {
+    /// Short machine-readable slug, suitable for logs and monitoring.
+    pub fn code(&self) -> u32 {
+        *self as u32
+    }
+
+    /// Human-readable description of what went wrong.
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::Unauthorized            => "Caller is not authorized on this contract",
+            Self::InsufficientPermissions => "Caller's role does not allow this action",
+            Self::AuthExpired             => "Authorization has expired; please re-authenticate",
+            Self::AlreadyInitialized      => "Contract has already been initialized",
+
+            Self::PolicyNotFound          => "No policy found with the given ID",
+            Self::PolicyInvalidState      => "Policy is in a state that does not permit this action",
+            Self::PolicyExpired           => "Policy coverage period has ended",
+            Self::PolicyAlreadyCancelled  => "Policy has already been cancelled",
+            Self::PolicyCoverageOutOfRange => "Coverage amount is outside the permitted range",
+
+            Self::ClaimNotFound           => "No claim found with the given ID",
+            Self::ClaimExceedsLimit       => "Claim amount exceeds the policy coverage limit",
+            Self::ClaimDuplicate          => "A claim for this event already exists",
+            Self::ClaimDeadlineExceeded   => "Claim was submitted past the filing deadline",
+            Self::ClaimInvalidState       => "Claim is in a state that does not permit this action",
+            Self::ClaimMissingDocuments   => "Required documentation for the claim is missing",
+
+            Self::PaymentInvalidAmount    => "Payment amount must be greater than zero",
+            Self::PaymentUnsupportedAsset => "This asset type is not accepted for payment",
+            Self::PremiumPaymentOverdue   => "Premium payment is past the due date",
+            Self::RefundExceedsBalance    => "Refund amount exceeds the available balance",
+
+            Self::KycNotVerified          => "Policy holder has not completed identity verification",
+            Self::KycExpired              => "Identity verification has expired and must be renewed",
+            Self::KycDocumentRejected     => "Submitted KYC documents were not accepted",
+            Self::ComplianceViolation     => "Operation is blocked by a regulatory restriction",
+
+            Self::RecordNotFound          => "The requested record does not exist in storage",
+            Self::InvalidData             => "Provided data is malformed or out of range",
+            Self::StorageExpired          => "Storage entry has expired; re-submit the data",
+
+            Self::OracleDataMissing       => "Oracle has not published data for this feed",
+            Self::OracleDataStale         => "Oracle data is too old to be used for this operation",
+            Self::ExternalCallFailed      => "A required external contract call failed",
+
+            Self::ContractPaused          => "Contract is paused; try again later",
+            Self::NotImplemented          => "This feature is not yet available",
+            Self::ArithmeticOverflow      => "Calculation resulted in an overflow",
+            Self::LimitExceeded           => "Value exceeds the maximum allowed limit",
+        }
+    }
+
+    /// Suggested recovery action for the caller.
+    pub fn hint(&self) -> &'static str {
+        match self {
+            Self::Unauthorized            => "Request access from the contract admin",
+            Self::InsufficientPermissions => "Check which role is required and request it from admin",
+            Self::AuthExpired             => "Re-authenticate and retry the operation",
+            Self::AlreadyInitialized      => "No action needed; contract is ready",
+
+            Self::PolicyNotFound          => "Verify the policy ID and try again",
+            Self::PolicyInvalidState      => "Check the policy lifecycle state before retrying",
+            Self::PolicyExpired           => "Renew the policy before attempting this action",
+            Self::PolicyAlreadyCancelled  => "Create a new policy if coverage is still required",
+            Self::PolicyCoverageOutOfRange => "Adjust the coverage amount to within allowed limits",
+
+            Self::ClaimNotFound           => "Verify the claim ID and try again",
+            Self::ClaimExceedsLimit       => "Reduce the claim amount to within coverage limits",
+            Self::ClaimDuplicate          => "Retrieve the existing claim instead of submitting a new one",
+            Self::ClaimDeadlineExceeded   => "Contact support for late-filing assistance",
+            Self::ClaimInvalidState       => "Check the claim status before retrying",
+            Self::ClaimMissingDocuments   => "Upload the required documents and resubmit",
+
+            Self::PaymentInvalidAmount    => "Provide a positive payment amount",
+            Self::PaymentUnsupportedAsset => "Use an accepted asset (e.g., USDC)",
+            Self::PremiumPaymentOverdue   => "Pay the overdue premium to reinstate the policy",
+            Self::RefundExceedsBalance    => "Request a refund of at most the paid balance",
+
+            Self::KycNotVerified          => "Complete KYC verification to proceed",
+            Self::KycExpired              => "Renew identity verification to continue",
+            Self::KycDocumentRejected     => "Resubmit corrected documents for review",
+            Self::ComplianceViolation     => "Contact compliance team to resolve the restriction",
+
+            Self::RecordNotFound          => "Confirm the ID is correct and retry",
+            Self::InvalidData             => "Validate all field formats and ranges before retrying",
+            Self::StorageExpired          => "Re-submit the data to refresh the storage entry",
+
+            Self::OracleDataMissing       => "Wait for the oracle to publish and retry",
+            Self::OracleDataStale         => "Wait for a fresh oracle update and retry",
+            Self::ExternalCallFailed      => "Check the external contract status and retry",
+
+            Self::ContractPaused          => "Monitor for a resume announcement and retry later",
+            Self::NotImplemented          => "Use an alternative method or wait for the next release",
+            Self::ArithmeticOverflow      => "Reduce the input values and retry",
+            Self::LimitExceeded           => "Reduce the value to within the allowed limit",
+        }
+    }
+
+    /// Whether this error is transient (safe to retry automatically).
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::OracleDataMissing
+                | Self::OracleDataStale
+                | Self::ExternalCallFailed
+                | Self::ContractPaused
+        )
+    }
+
+    /// Whether this error requires human intervention before retrying.
+    pub fn requires_manual_action(&self) -> bool {
+        matches!(
+            self,
+            Self::KycNotVerified
+                | Self::KycExpired
+                | Self::KycDocumentRejected
+                | Self::ComplianceViolation
+                | Self::ClaimMissingDocuments
+                | Self::ClaimDeadlineExceeded
+        )
+    }
+}

--- a/stellar-insured-contracts/contracts/error_handling/src/lib.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+mod codes;
+mod recovery;
+mod registry;
+mod types;
+
+pub use codes::InsuranceError;
+pub use recovery::RecoveryContract;
+pub use types::{ErrorEntry, ErrorSeverity, RecoveryAction, RecoveryStatus};
+
+#[cfg(test)]
+mod test;

--- a/stellar-insured-contracts/contracts/error_handling/src/recovery.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/recovery.rs
@@ -1,0 +1,231 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+
+use crate::{
+    codes::InsuranceError,
+    registry,
+    types::{ErrorEntry, ErrorSeverity, RecoveryAction, RecoveryStatus},
+};
+
+#[contract]
+pub struct RecoveryContract;
+
+#[contractimpl]
+impl RecoveryContract {
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address) -> Result<(), InsuranceError> {
+        if registry::has_admin(&env) {
+            return Err(InsuranceError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        registry::set_admin(&env, &admin);
+        Ok(())
+    }
+
+    pub fn authorize_reporter(env: Env, reporter: Address) -> Result<(), InsuranceError> {
+        registry::get_admin(&env).require_auth();
+        registry::set_authorized_reporter(&env, &reporter, true);
+        Ok(())
+    }
+
+    pub fn revoke_reporter(env: Env, reporter: Address) -> Result<(), InsuranceError> {
+        registry::get_admin(&env).require_auth();
+        registry::set_authorized_reporter(&env, &reporter, false);
+        Ok(())
+    }
+
+    // ── Error Reporting ───────────────────────────────────────────────────────
+
+    /// Report an error from any authorized contract.
+    /// Automatically derives severity, recovery action, and hint from the error code.
+    pub fn report_error(
+        env: Env,
+        source_contract: Address,
+        caller: Address,
+        error: InsuranceError,
+        subject_id: Option<u64>,
+    ) -> Result<u64, InsuranceError> {
+        source_contract.require_auth();
+        if !registry::is_authorized_reporter(&env, &source_contract) {
+            return Err(InsuranceError::Unauthorized);
+        }
+        if registry::is_paused(&env) {
+            return Err(InsuranceError::ContractPaused);
+        }
+
+        let severity = Self::derive_severity(&error);
+        let recovery_action = Self::derive_recovery_action(&error);
+
+        let entry_id = registry::next_error_id(&env);
+        let entry = ErrorEntry {
+            entry_id,
+            error_code: error.code(),
+            severity: severity.clone(),
+            source_contract: source_contract.clone(),
+            caller,
+            ledger: env.ledger().sequence(),
+            timestamp: env.ledger().timestamp(),
+            message: String::from_str(&env, error.message()),
+            hint: String::from_str(&env, error.hint()),
+            recovery_action: recovery_action.clone(),
+            recovery_status: RecoveryStatus::Pending,
+            subject_id,
+        };
+
+        registry::save_error(&env, &entry);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("err"), entry_id),
+            (error.code(), source_contract, severity, recovery_action),
+        );
+
+        Ok(entry_id)
+    }
+
+    // ── Recovery Management ───────────────────────────────────────────────────
+
+    /// Mark an error as resolved (admin or the reporting contract).
+    pub fn resolve_error(env: Env, caller: Address, entry_id: u64) -> Result<(), InsuranceError> {
+        caller.require_auth();
+        let admin = registry::get_admin(&env);
+        if caller != admin && !registry::is_authorized_reporter(&env, &caller) {
+            return Err(InsuranceError::Unauthorized);
+        }
+
+        let mut entry = registry::get_error(&env, entry_id)
+            .ok_or(InsuranceError::RecordNotFound)?;
+
+        entry.recovery_status = RecoveryStatus::Resolved;
+        registry::save_error(&env, &entry);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("resolved"), entry_id),
+            (caller,),
+        );
+        Ok(())
+    }
+
+    /// Escalate a pending error to the operator for manual intervention.
+    pub fn escalate_error(env: Env, entry_id: u64) -> Result<(), InsuranceError> {
+        registry::get_admin(&env).require_auth();
+
+        let mut entry = registry::get_error(&env, entry_id)
+            .ok_or(InsuranceError::RecordNotFound)?;
+
+        entry.recovery_action = RecoveryAction::ManualInterventionRequired;
+        entry.recovery_status = RecoveryStatus::EscalatedToOperator;
+        registry::save_error(&env, &entry);
+
+        env.events().publish(
+            (soroban_sdk::symbol_short!("escalated"), entry_id),
+            (entry.error_code,),
+        );
+        Ok(())
+    }
+
+    // ── Emergency Controls ────────────────────────────────────────────────────
+
+    /// Pause all error reporting (emergency stop).
+    pub fn pause(env: Env) -> Result<(), InsuranceError> {
+        registry::get_admin(&env).require_auth();
+        registry::set_paused(&env, true);
+        env.events().publish((soroban_sdk::symbol_short!("paused"),), ());
+        Ok(())
+    }
+
+    /// Resume error reporting.
+    pub fn resume(env: Env) -> Result<(), InsuranceError> {
+        registry::get_admin(&env).require_auth();
+        registry::set_paused(&env, false);
+        env.events().publish((soroban_sdk::symbol_short!("resumed"),), ());
+        Ok(())
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    pub fn get_error(env: Env, entry_id: u64) -> Result<ErrorEntry, InsuranceError> {
+        registry::get_error(&env, entry_id).ok_or(InsuranceError::RecordNotFound)
+    }
+
+    pub fn get_error_count(env: Env) -> u64 {
+        registry::get_error_count(&env)
+    }
+
+    /// Fetch pending (unresolved) errors, paginated, max 50.
+    pub fn get_pending_errors(
+        env: Env,
+        caller: Address,
+        from_id: u64,
+        limit: u32,
+    ) -> Result<Vec<ErrorEntry>, InsuranceError> {
+        caller.require_auth();
+        let admin = registry::get_admin(&env);
+        if caller != admin && !registry::is_authorized_reporter(&env, &caller) {
+            return Err(InsuranceError::Unauthorized);
+        }
+
+        let limit = limit.min(50);
+        let total = registry::get_error_count(&env);
+        let mut results: Vec<ErrorEntry> = Vec::new(&env);
+        let mut id = from_id;
+        let mut found: u32 = 0;
+
+        while id <= total && found < limit {
+            if let Some(entry) = registry::get_error(&env, id) {
+                if matches!(entry.recovery_status, RecoveryStatus::Pending) {
+                    results.push_back(entry);
+                    found += 1;
+                }
+            }
+            id += 1;
+        }
+        Ok(results)
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        registry::get_admin(&env)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        registry::is_paused(&env)
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    fn derive_severity(error: &InsuranceError) -> ErrorSeverity {
+        match error {
+            InsuranceError::ArithmeticOverflow
+            | InsuranceError::ContractPaused
+            | InsuranceError::ComplianceViolation => ErrorSeverity::Critical,
+
+            InsuranceError::Unauthorized
+            | InsuranceError::ClaimExceedsLimit
+            | InsuranceError::PremiumPaymentOverdue
+            | InsuranceError::ExternalCallFailed => ErrorSeverity::Error,
+
+            InsuranceError::OracleDataStale
+            | InsuranceError::KycExpired
+            | InsuranceError::StorageExpired => ErrorSeverity::Warning,
+
+            _ => ErrorSeverity::Info,
+        }
+    }
+
+    fn derive_recovery_action(error: &InsuranceError) -> RecoveryAction {
+        if error.is_retryable() {
+            return RecoveryAction::AutoRetried;
+        }
+        if error.requires_manual_action() {
+            return RecoveryAction::ManualInterventionRequired;
+        }
+        match error {
+            InsuranceError::ArithmeticOverflow => RecoveryAction::StateRolledBack,
+            InsuranceError::ContractPaused     => RecoveryAction::ContractPaused,
+            InsuranceError::PaymentInvalidAmount
+            | InsuranceError::ClaimExceedsLimit => RecoveryAction::FundsEscrowed,
+            _ => RecoveryAction::None,
+        }
+    }
+}

--- a/stellar-insured-contracts/contracts/error_handling/src/registry.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/registry.rs
@@ -1,0 +1,66 @@
+#![no_std]
+
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, ErrorEntry};
+
+const LONG_TTL: u32 = 63_072_000; // ~10 years at 5s/ledger
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().persistent().set(&DataKey::Admin, admin);
+    env.storage().persistent().extend_ttl(&DataKey::Admin, LONG_TTL, LONG_TTL);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().persistent().get(&DataKey::Admin).unwrap()
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().persistent().has(&DataKey::Admin)
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage().persistent().set(&DataKey::Paused, &paused);
+    env.storage().persistent().extend_ttl(&DataKey::Paused, LONG_TTL, LONG_TTL);
+}
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage().persistent().get(&DataKey::Paused).unwrap_or(false)
+}
+
+pub fn set_authorized_reporter(env: &Env, reporter: &Address, authorized: bool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::AuthorizedReporter(reporter.clone()), &authorized);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::AuthorizedReporter(reporter.clone()), LONG_TTL, LONG_TTL);
+}
+
+pub fn is_authorized_reporter(env: &Env, reporter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::AuthorizedReporter(reporter.clone()))
+        .unwrap_or(false)
+}
+
+pub fn next_error_id(env: &Env) -> u64 {
+    let count: u64 = env.storage().persistent().get(&DataKey::ErrorCount).unwrap_or(0) + 1;
+    env.storage().persistent().set(&DataKey::ErrorCount, &count);
+    env.storage().persistent().extend_ttl(&DataKey::ErrorCount, LONG_TTL, LONG_TTL);
+    count
+}
+
+pub fn get_error_count(env: &Env) -> u64 {
+    env.storage().persistent().get(&DataKey::ErrorCount).unwrap_or(0)
+}
+
+pub fn save_error(env: &Env, entry: &ErrorEntry) {
+    let key = DataKey::Error(entry.entry_id);
+    env.storage().persistent().set(&key, entry);
+    env.storage().persistent().extend_ttl(&key, LONG_TTL, LONG_TTL);
+}
+
+pub fn get_error(env: &Env, id: u64) -> Option<ErrorEntry> {
+    env.storage().persistent().get(&DataKey::Error(id))
+}

--- a/stellar-insured-contracts/contracts/error_handling/src/test.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/test.rs
@@ -1,0 +1,293 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+
+use crate::{
+    codes::InsuranceError,
+    recovery::RecoveryContract,
+    types::{ErrorSeverity, RecoveryAction, RecoveryStatus},
+    RecoveryContractClient,
+};
+
+fn setup() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 1_700_000_000,
+        protocol_version: 20,
+        sequence_number: 100,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 100_000_000,
+    });
+    let id = env.register_contract(None, RecoveryContract);
+    let admin = Address::generate(&env);
+    (env, id, admin)
+}
+
+fn client<'a>(env: &'a Env, id: &'a Address) -> RecoveryContractClient<'a> {
+    RecoveryContractClient::new(env, id)
+}
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    c.initialize(&admin);
+    assert_eq!(c.get_admin(), admin);
+}
+
+#[test]
+fn test_double_initialize_fails() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    c.initialize(&admin);
+    assert_eq!(
+        c.try_initialize(&admin),
+        Err(Ok(InsuranceError::AlreadyInitialized))
+    );
+}
+
+// ── Error Codes ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_error_codes_are_unique_and_in_range() {
+    // Auth range
+    assert_eq!(InsuranceError::Unauthorized as u32, 1);
+    assert_eq!(InsuranceError::AlreadyInitialized as u32, 4);
+    // Policy range
+    assert_eq!(InsuranceError::PolicyNotFound as u32, 100);
+    // Claims range
+    assert_eq!(InsuranceError::ClaimNotFound as u32, 200);
+    // Payments range
+    assert_eq!(InsuranceError::PaymentInvalidAmount as u32, 300);
+    // KYC range
+    assert_eq!(InsuranceError::KycNotVerified as u32, 400);
+    // System range
+    assert_eq!(InsuranceError::ContractPaused as u32, 700);
+}
+
+#[test]
+fn test_error_messages_are_non_empty() {
+    let errors = [
+        InsuranceError::Unauthorized,
+        InsuranceError::PolicyNotFound,
+        InsuranceError::ClaimExceedsLimit,
+        InsuranceError::PaymentInvalidAmount,
+        InsuranceError::KycNotVerified,
+        InsuranceError::OracleDataStale,
+        InsuranceError::ArithmeticOverflow,
+    ];
+    for e in &errors {
+        assert!(!e.message().is_empty());
+        assert!(!e.hint().is_empty());
+    }
+}
+
+#[test]
+fn test_retryable_errors() {
+    assert!(InsuranceError::OracleDataMissing.is_retryable());
+    assert!(InsuranceError::OracleDataStale.is_retryable());
+    assert!(InsuranceError::ExternalCallFailed.is_retryable());
+    assert!(InsuranceError::ContractPaused.is_retryable());
+    assert!(!InsuranceError::Unauthorized.is_retryable());
+    assert!(!InsuranceError::ClaimDuplicate.is_retryable());
+}
+
+#[test]
+fn test_manual_action_errors() {
+    assert!(InsuranceError::KycNotVerified.requires_manual_action());
+    assert!(InsuranceError::ClaimMissingDocuments.requires_manual_action());
+    assert!(!InsuranceError::PolicyNotFound.requires_manual_action());
+}
+
+// ── Reporting ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_report_error_success() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(
+        &reporter,
+        &caller,
+        &InsuranceError::PolicyNotFound,
+        &None,
+    );
+
+    assert_eq!(entry_id, 1u64);
+    assert_eq!(c.get_error_count(), 1u64);
+
+    let entry = c.get_error(&1u64);
+    assert_eq!(entry.error_code, InsuranceError::PolicyNotFound as u32);
+    assert!(matches!(entry.severity, ErrorSeverity::Info));
+    assert!(matches!(entry.recovery_status, RecoveryStatus::Pending));
+}
+
+#[test]
+fn test_critical_error_severity() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(
+        &reporter,
+        &caller,
+        &InsuranceError::ArithmeticOverflow,
+        &None,
+    );
+
+    let entry = c.get_error(&entry_id);
+    assert!(matches!(entry.severity, ErrorSeverity::Critical));
+    assert!(matches!(entry.recovery_action, RecoveryAction::StateRolledBack));
+}
+
+#[test]
+fn test_retryable_error_gets_auto_retry_action() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(
+        &reporter, &caller, &InsuranceError::OracleDataStale, &None,
+    );
+    let entry = c.get_error(&entry_id);
+    assert!(matches!(entry.recovery_action, RecoveryAction::AutoRetried));
+}
+
+#[test]
+fn test_unauthorized_reporter_fails() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let not_reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+
+    assert_eq!(
+        c.try_report_error(&not_reporter, &caller, &InsuranceError::PolicyNotFound, &None),
+        Err(Ok(InsuranceError::Unauthorized))
+    );
+}
+
+// ── Recovery ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_resolve_error() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(&reporter, &caller, &InsuranceError::ClaimNotFound, &None);
+    c.resolve_error(&admin, &entry_id);
+
+    let entry = c.get_error(&entry_id);
+    assert!(matches!(entry.recovery_status, RecoveryStatus::Resolved));
+}
+
+#[test]
+fn test_escalate_error() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(&reporter, &caller, &InsuranceError::ComplianceViolation, &None);
+    c.escalate_error(&entry_id);
+
+    let entry = c.get_error(&entry_id);
+    assert!(matches!(entry.recovery_status, RecoveryStatus::EscalatedToOperator));
+    assert!(matches!(entry.recovery_action, RecoveryAction::ManualInterventionRequired));
+}
+
+// ── Emergency Controls ────────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_and_resume() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+    c.pause();
+
+    assert!(c.is_paused());
+    assert_eq!(
+        c.try_report_error(&reporter, &caller, &InsuranceError::PolicyNotFound, &None),
+        Err(Ok(InsuranceError::ContractPaused))
+    );
+
+    c.resume();
+    assert!(!c.is_paused());
+    // Should succeed now
+    c.report_error(&reporter, &caller, &InsuranceError::PolicyNotFound, &None);
+}
+
+// ── Pending Query ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_pending_errors() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let id1 = c.report_error(&reporter, &caller, &InsuranceError::PolicyNotFound, &None);
+    let id2 = c.report_error(&reporter, &caller, &InsuranceError::ClaimDuplicate, &None);
+    c.resolve_error(&admin, &id1);
+
+    let pending = c.get_pending_errors(&admin, &1u64, &20u32);
+    // Only id2 should remain pending
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending.get(0).unwrap().entry_id, id2);
+}
+
+#[test]
+fn test_subject_id_recorded() {
+    let (env, id, admin) = setup();
+    let c = client(&env, &id);
+    let reporter = Address::generate(&env);
+    let caller = Address::generate(&env);
+
+    c.initialize(&admin);
+    c.authorize_reporter(&reporter);
+
+    let entry_id = c.report_error(
+        &reporter, &caller, &InsuranceError::ClaimNotFound, &Some(42u64),
+    );
+
+    let entry = c.get_error(&entry_id);
+    assert_eq!(entry.subject_id, Some(42u64));
+}

--- a/stellar-insured-contracts/contracts/error_handling/src/types.rs
+++ b/stellar-insured-contracts/contracts/error_handling/src/types.rs
@@ -1,0 +1,76 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, Address, String};
+
+/// How serious the error is.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ErrorSeverity {
+    /// Informational — no immediate action required
+    Info,
+    /// Unexpected but non-blocking
+    Warning,
+    /// Operation failed; caller must take action
+    Error,
+    /// System-level failure; requires operator intervention
+    Critical,
+}
+
+/// What action was taken (or should be taken) to recover.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecoveryAction {
+    /// No recovery needed or possible
+    None,
+    /// Operation was retried automatically and succeeded
+    AutoRetried,
+    /// State was rolled back to the last known-good snapshot
+    StateRolledBack,
+    /// Contract was paused pending operator review
+    ContractPaused,
+    /// Funds were redirected to the escrow/fallback address
+    FundsEscrowed,
+    /// Operator must intervene manually
+    ManualInterventionRequired,
+}
+
+/// Current status of a recovery attempt.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecoveryStatus {
+    Pending,
+    Resolved,
+    Failed,
+    EscalatedToOperator,
+}
+
+/// A single error event recorded in the on-chain error log.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ErrorEntry {
+    pub entry_id: u64,
+    pub error_code: u32,
+    pub severity: ErrorSeverity,
+    pub source_contract: Address,
+    pub caller: Address,
+    pub ledger: u32,
+    pub timestamp: u64,
+    /// Static message from InsuranceError::message()
+    pub message: String,
+    /// Static hint from InsuranceError::hint()
+    pub hint: String,
+    pub recovery_action: RecoveryAction,
+    pub recovery_status: RecoveryStatus,
+    /// Optional ID in the domain object that was involved (policy, claim, etc.)
+    pub subject_id: Option<u64>,
+}
+
+/// Storage keys
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Paused,
+    ErrorCount,
+    Error(u64),
+    AuthorizedReporter(Address),
+}


### PR DESCRIPTION
Introduces a new error_handling Soroban contract that unifies error codes across all platform contracts. Errors are grouped into numbered ranges by domain (auth, policy, claims, payments, KYC, system) and are self-documenting — each carries a message, a user-facing hint, and flags for whether it's retryable or requires manual action. Includes a RecoveryContract for on-chain error logging, resolve/escalate lifecycle management, and an emergency pause mechanism.

closes #60 