### PR TITLE
Feature/no reentrancy guards on fund transfers

### DIFF
--- a/stellar-insured-contracts/contracts/escrow/src/lib.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/lib.rs
@@ -29,6 +29,7 @@ mod propchain_escrow {
         InvalidConfiguration,
         EscrowAlreadyFunded,
         ParticipantNotFound,
+        ReentrancyDetected,
     }
 
     /// Escrow status enumeration
@@ -159,6 +160,8 @@ mod propchain_escrow {
         admin: AccountId,
         /// High-value threshold for mandatory multi-sig
         min_high_value_threshold: u128,
+        /// Reentrancy guard for fund transfer operations
+        reentrancy_lock: bool,
     }
 
     // Events
@@ -276,6 +279,7 @@ mod propchain_escrow {
                 audit_logs: Mapping::default(),
                 admin: Self::env().caller(),
                 min_high_value_threshold,
+                reentrancy_lock: false,
             }
         }
 
@@ -432,31 +436,35 @@ mod propchain_escrow {
                 return Err(Error::SignatureThresholdNotMet);
             }
 
-            // Transfer funds to seller
-            if self
-                .env()
-                .transfer(escrow.seller, escrow.deposited_amount)
-                .is_err()
-            {
-                return Err(Error::InsufficientFunds);
-            }
+            self.try_enter_reentrancy_guard()?;
 
-            // Update status
+            // Update state first (checks-effects-interactions)
+            let transfer_amount = escrow.deposited_amount;
             let mut updated_escrow = escrow.clone();
             updated_escrow.status = EscrowStatus::Released;
+            updated_escrow.deposited_amount = 0;
             self.escrows.insert(&escrow_id, &updated_escrow);
+
+            // Transfer funds to seller
+            if self.env().transfer(escrow.seller, transfer_amount).is_err() {
+                // Roll back state on failed interaction
+                self.escrows.insert(&escrow_id, &escrow);
+                self.exit_reentrancy_guard();
+                return Err(Error::InsufficientFunds);
+            }
+            self.exit_reentrancy_guard();
 
             // Add audit entry
             self.add_audit_entry(
                 escrow_id,
                 caller,
                 "FundsReleased".to_string(),
-                format!("Amount: {} to seller", escrow.deposited_amount),
+                format!("Amount: {} to seller", transfer_amount),
             );
 
             self.env().emit_event(FundsReleased {
                 escrow_id,
-                amount: escrow.deposited_amount,
+                amount: transfer_amount,
                 recipient: escrow.seller,
             });
 
@@ -479,31 +487,35 @@ mod propchain_escrow {
                 return Err(Error::SignatureThresholdNotMet);
             }
 
-            // Transfer funds back to buyer
-            if self
-                .env()
-                .transfer(escrow.buyer, escrow.deposited_amount)
-                .is_err()
-            {
-                return Err(Error::InsufficientFunds);
-            }
+            self.try_enter_reentrancy_guard()?;
 
-            // Update status
+            // Update state first (checks-effects-interactions)
+            let transfer_amount = escrow.deposited_amount;
             let mut updated_escrow = escrow.clone();
             updated_escrow.status = EscrowStatus::Refunded;
+            updated_escrow.deposited_amount = 0;
             self.escrows.insert(&escrow_id, &updated_escrow);
+
+            // Transfer funds back to buyer
+            if self.env().transfer(escrow.buyer, transfer_amount).is_err() {
+                // Roll back state on failed interaction
+                self.escrows.insert(&escrow_id, &escrow);
+                self.exit_reentrancy_guard();
+                return Err(Error::InsufficientFunds);
+            }
+            self.exit_reentrancy_guard();
 
             // Add audit entry
             self.add_audit_entry(
                 escrow_id,
                 caller,
                 "FundsRefunded".to_string(),
-                format!("Amount: {} to buyer", escrow.deposited_amount),
+                format!("Amount: {} to buyer", transfer_amount),
             );
 
             self.env().emit_event(FundsRefunded {
                 escrow_id,
-                amount: escrow.deposited_amount,
+                amount: transfer_amount,
                 recipient: escrow.buyer,
             });
 
@@ -866,30 +878,34 @@ mod propchain_escrow {
                 escrow.buyer
             };
 
-            // Transfer funds
-            if self
-                .env()
-                .transfer(recipient, escrow.deposited_amount)
-                .is_err()
-            {
-                return Err(Error::InsufficientFunds);
-            }
+            self.try_enter_reentrancy_guard()?;
 
-            // Update status
+            // Update state first (checks-effects-interactions)
+            let transfer_amount = escrow.deposited_amount;
             let mut updated_escrow = escrow.clone();
             updated_escrow.status = if release_to_seller {
                 EscrowStatus::Released
             } else {
                 EscrowStatus::Refunded
             };
+            updated_escrow.deposited_amount = 0;
             self.escrows.insert(&escrow_id, &updated_escrow);
+
+            // Transfer funds
+            if self.env().transfer(recipient, transfer_amount).is_err() {
+                // Roll back state on failed interaction
+                self.escrows.insert(&escrow_id, &escrow);
+                self.exit_reentrancy_guard();
+                return Err(Error::InsufficientFunds);
+            }
+            self.exit_reentrancy_guard();
 
             // Add audit entry
             self.add_audit_entry(
                 escrow_id,
                 caller,
                 "EmergencyOverride".to_string(),
-                format!("Funds sent to: {:?}", recipient),
+                format!("Amount: {} sent to: {:?}", transfer_amount, recipient),
             );
 
             self.env().emit_event(EmergencyOverride {
@@ -1022,6 +1038,20 @@ mod propchain_escrow {
             let mut logs = self.audit_logs.get(&escrow_id).unwrap_or_default();
             logs.push(entry);
             self.audit_logs.insert(&escrow_id, &logs);
+        }
+
+        /// Enter reentrancy-protected section
+        fn try_enter_reentrancy_guard(&mut self) -> Result<(), Error> {
+            if self.reentrancy_lock {
+                return Err(Error::ReentrancyDetected);
+            }
+            self.reentrancy_lock = true;
+            Ok(())
+        }
+
+        /// Exit reentrancy-protected section
+        fn exit_reentrancy_guard(&mut self) {
+            self.reentrancy_lock = false;
         }
     }
 

--- a/stellar-insured-contracts/contracts/escrow/src/tests.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/tests.rs
@@ -563,4 +563,133 @@ pub mod escrow_tests {
         assert_eq!(config.required_signatures, 2);
         assert_eq!(config.signers, participants);
     }
+
+    #[ink::test]
+    fn test_release_funds_updates_state_before_interaction_path() {
+        let accounts = default_accounts();
+        set_caller(accounts.alice);
+        set_balance(accounts.alice, 2_000_000);
+
+        let mut contract = AdvancedEscrow::new(1_000_000);
+        let participants = vec![accounts.alice, accounts.bob];
+
+        let escrow_id = contract
+            .create_escrow_advanced(
+                1,
+                1_000_000,
+                accounts.alice,
+                accounts.bob,
+                participants,
+                2,
+                None,
+            )
+            .expect("Escrow creation should succeed in test");
+
+        ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(1_000_000);
+        contract
+            .deposit_funds(escrow_id)
+            .expect("Deposit should succeed in test");
+
+        contract
+            .sign_approval(escrow_id, ApprovalType::Release)
+            .expect("First release signature should succeed in test");
+        set_caller(accounts.bob);
+        contract
+            .sign_approval(escrow_id, ApprovalType::Release)
+            .expect("Second release signature should succeed in test");
+
+        set_caller(accounts.alice);
+        contract
+            .release_funds(escrow_id)
+            .expect("Release should succeed in test");
+
+        let escrow = contract
+            .get_escrow(escrow_id)
+            .expect("Escrow should exist after release");
+        assert_eq!(escrow.status, EscrowStatus::Released);
+        assert_eq!(escrow.deposited_amount, 0);
+    }
+
+    #[ink::test]
+    fn test_refund_funds_updates_state_before_interaction_path() {
+        let accounts = default_accounts();
+        set_caller(accounts.alice);
+        set_balance(accounts.alice, 2_000_000);
+
+        let mut contract = AdvancedEscrow::new(1_000_000);
+        let participants = vec![accounts.alice, accounts.bob];
+
+        let escrow_id = contract
+            .create_escrow_advanced(
+                1,
+                1_000_000,
+                accounts.alice,
+                accounts.bob,
+                participants,
+                2,
+                None,
+            )
+            .expect("Escrow creation should succeed in test");
+
+        ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(1_000_000);
+        contract
+            .deposit_funds(escrow_id)
+            .expect("Deposit should succeed in test");
+
+        contract
+            .sign_approval(escrow_id, ApprovalType::Refund)
+            .expect("First refund signature should succeed in test");
+        set_caller(accounts.bob);
+        contract
+            .sign_approval(escrow_id, ApprovalType::Refund)
+            .expect("Second refund signature should succeed in test");
+
+        set_caller(accounts.alice);
+        contract
+            .refund_funds(escrow_id)
+            .expect("Refund should succeed in test");
+
+        let escrow = contract
+            .get_escrow(escrow_id)
+            .expect("Escrow should exist after refund");
+        assert_eq!(escrow.status, EscrowStatus::Refunded);
+        assert_eq!(escrow.deposited_amount, 0);
+    }
+
+    #[ink::test]
+    fn test_emergency_override_updates_state_before_interaction_path() {
+        let accounts = default_accounts();
+        set_caller(accounts.alice);
+        set_balance(accounts.alice, 2_000_000);
+
+        let mut contract = AdvancedEscrow::new(1_000_000);
+        let participants = vec![accounts.alice, accounts.bob];
+
+        let escrow_id = contract
+            .create_escrow_advanced(
+                1,
+                1_000_000,
+                accounts.alice,
+                accounts.bob,
+                participants,
+                2,
+                None,
+            )
+            .expect("Escrow creation should succeed in test");
+
+        ink::env::test::set_value_transferred::<ink::env::DefaultEnvironment>(1_000_000);
+        contract
+            .deposit_funds(escrow_id)
+            .expect("Deposit should succeed in test");
+
+        contract
+            .emergency_override(escrow_id, true)
+            .expect("Emergency override should succeed in test");
+
+        let escrow = contract
+            .get_escrow(escrow_id)
+            .expect("Escrow should exist after emergency override");
+        assert_eq!(escrow.status, EscrowStatus::Released);
+        assert_eq!(escrow.deposited_amount, 0);
+    }
 }


### PR DESCRIPTION
# Fix: Add Reentrancy Guards to Fund Transfer Operations

## Severity
**Critical** – This vulnerability exposes contract funds to drain attacks via malicious recursive calls.

## Description
Multiple fund transfer operations in the escrow contract violate the Checks-Effects-Interactions pattern by transferring funds **before** updating internal state. This creates a reentrancy vector where a malicious recipient can recursively call back into the contract during the transfer, draining funds multiple times before the first withdrawal is recorded.

## Affected Functions
| Function | Lines |
|----------|-------|
| `release_funds` | 436-442 |
| `refund_funds` | 483-489 |
| `emergency_override` | 870-876 |

## Fix Applied
- Reordered operations to follow **Checks → Effects → Interactions** pattern:
  1. Validate conditions (Checks)
  2. Update state variables (Effects)
  3. Perform external transfer (Interactions)
- State is now updated **before** any token transfer occurs
- Reentrancy attack vector eliminated

## Before (Vulnerable)
```rust
// ❌ Transfer before state update
transfer_funds(recipient, amount);
self.balances[recipient] -= amount;  // State updated after
```

## After (Secure)
```rust
// ✅ State updated before transfer
self.balances[recipient] -= amount;
transfer_funds(recipient, amount);
```

## Verification
- All three functions follow Checks-Effects-Interactions
- No external calls occur before state changes
- Existing test suite passes
- Manual reentrancy attack simulation fails

Closes #259