### PR TITLE
fix: error handling, transfer_admin, init validation, gas estimates

### DIFF
--- a/stellar-insured-contracts/contracts/bridge/src/lib.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/lib.rs
@@ -158,7 +158,20 @@ mod bridge {
             default_timeout: u64,
             gas_limit: u64,
             property_token_contract: AccountId,
-        ) -> Self {
+        ) -> Result<Self, Error> {
+            if supported_chains.is_empty() {
+                return Err(Error::InvalidRequest);
+            }
+            if min_signatures == 0 || min_signatures > max_signatures {
+                return Err(Error::InsufficientSignatures);
+            }
+            if gas_limit == 0 {
+                return Err(Error::GasLimitExceeded);
+            }
+            if default_timeout == 0 {
+                return Err(Error::InvalidRequest);
+            }
+
             let caller = Self::env().caller();
             let config = BridgeConfig {
                 supported_chains: supported_chains.clone(),
@@ -199,7 +212,7 @@ mod bridge {
                 bridge.chain_info.insert(chain_id, &chain_info);
             }
 
-            bridge
+            Ok(bridge)
         }
 
         /// Initiates a bridge request with multi-signature requirement
@@ -774,9 +787,13 @@ mod bridge {
         }
 
         fn estimate_gas_usage(&self, request: &MultisigBridgeRequest) -> u64 {
-            // Estimate gas usage based on request complexity
-            let base_gas = 100000; // Base gas for bridge operation
-            let metadata_gas = request.metadata.legal_description.len() as u64 * 100; // Gas for metadata
+            let base_gas = self.config.gas_limit_per_bridge;
+            let per_byte = self
+                .chain_info
+                .get(request.destination_chain)
+                .map(|c| c.gas_multiplier as u64)
+                .unwrap_or(100);
+            let metadata_gas = request.metadata.legal_description.len() as u64 * per_byte / 100;
             base_gas + metadata_gas
         }
 
@@ -881,6 +898,7 @@ mod bridge {
             // path is covered by integration / e2e tests.
             let dummy_token_contract = AccountId::from([0x01u8; 32]);
             PropertyBridge::new(supported_chains, 2, 5, 100, 500000, dummy_token_contract)
+                .expect("valid constructor args")
         }
 
         #[ink::test]

--- a/stellar-insured-contracts/contracts/escrow/src/lib.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/lib.rs
@@ -1,5 +1,18 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Map, Vec, Val, symbol_short};
+use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, Symbol, Map, Vec, Val, symbol_short};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    InvalidAmount = 4,
+    BuyerSellerSame = 5,
+    EscrowNotFound = 6,
+    InvalidState = 7,
+}
 
 #[contract]
 pub struct EscrowContract;
@@ -7,12 +20,25 @@ pub struct EscrowContract;
 #[contractimpl]
 impl EscrowContract {
     /// Initialize the escrow contract
-    pub fn init(env: Env, admin: Address) {
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
         if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
+            return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&symbol_short!("admin"), &admin);
         env.storage().instance().set(&symbol_short!("escrow_count"), &0u64);
+        Ok(())
+    }
+
+    /// Transfer admin to a new address (admin only)
+    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
+        Ok(())
     }
 
     /// Create a new escrow
@@ -22,23 +48,44 @@ impl EscrowContract {
         buyer: Address,
         seller: Address,
         amount: u128,
-    ) -> u64 {
-        let admin: Address = env.storage().instance().get(&symbol_short!("admin")).unwrap();
+    ) -> Result<u64, Error> {
+        if amount == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        if buyer == seller {
+            return Err(Error::BuyerSellerSame);
+        }
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
-        let mut escrow_count: u64 = env.storage().instance().get(&symbol_short!("escrow_count")).unwrap_or(0);
+        let mut escrow_count: u64 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("escrow_count"))
+            .unwrap_or(0);
         escrow_count += 1;
-        env.storage().instance().set(&symbol_short!("escrow_count"), &escrow_count);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("escrow_count"), &escrow_count);
 
         let escrow_key = symbol_short!("escrow");
-        let mut escrows: Map<u64, Val> = env.storage().instance().get(&escrow_key).unwrap_or(Map::new(&env));
+        let mut escrows: Map<u64, Val> = env
+            .storage()
+            .instance()
+            .get(&escrow_key)
+            .unwrap_or(Map::new(&env));
 
         let escrow_data = (
             property_id,
             buyer.clone(),
             seller.clone(),
             amount,
-            0u128, // deposited_amount
+            0u128,                    // deposited_amount
             symbol_short!("created"), // status
             env.ledger().timestamp(), // created_at
         );
@@ -46,22 +93,33 @@ impl EscrowContract {
         escrows.set(escrow_count, escrow_data.into());
         env.storage().instance().set(&escrow_key, &escrows);
 
-        escrow_count
+        Ok(escrow_count)
     }
 
     /// Deposit funds into escrow
-    pub fn deposit_funds(env: Env, escrow_id: u64, amount: u128) {
-        let escrow_key = symbol_short!("escrow");
-        let mut escrows: Map<u64, Val> = env.storage().instance().get(&escrow_key).unwrap();
-        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows.get(escrow_id).unwrap().into();
-
-        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) = escrow_data;
-
-        if status != symbol_short!("created") {
-            panic!("Escrow not in created state");
+    pub fn deposit_funds(env: Env, escrow_id: u64, amount: u128) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::InvalidAmount);
         }
 
-        // Transfer tokens (simplified - in real implementation would transfer actual tokens)
+        let escrow_key = symbol_short!("escrow");
+        let mut escrows: Map<u64, Val> = env
+            .storage()
+            .instance()
+            .get(&escrow_key)
+            .ok_or(Error::NotInitialized)?;
+        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows
+            .get(escrow_id)
+            .ok_or(Error::EscrowNotFound)?
+            .into();
+
+        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) =
+            escrow_data;
+
+        if status != symbol_short!("created") {
+            return Err(Error::InvalidState);
+        }
+
         buyer.require_auth();
 
         let new_deposited = deposited_amount + amount;
@@ -71,40 +129,75 @@ impl EscrowContract {
             symbol_short!("created")
         };
 
-        let updated_escrow = (property_id, buyer, seller, total_amount, new_deposited, new_status, created_at);
+        let updated_escrow = (
+            property_id,
+            buyer,
+            seller,
+            total_amount,
+            new_deposited,
+            new_status,
+            created_at,
+        );
         escrows.set(escrow_id, updated_escrow.into());
         env.storage().instance().set(&escrow_key, &escrows);
+        Ok(())
     }
 
     /// Release escrow funds
-    pub fn release_escrow(env: Env, escrow_id: u64) {
+    pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
         let escrow_key = symbol_short!("escrow");
-        let mut escrows: Map<u64, Val> = env.storage().instance().get(&escrow_key).unwrap();
-        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows.get(escrow_id).unwrap().into();
+        let mut escrows: Map<u64, Val> = env
+            .storage()
+            .instance()
+            .get(&escrow_key)
+            .ok_or(Error::NotInitialized)?;
+        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows
+            .get(escrow_id)
+            .ok_or(Error::EscrowNotFound)?
+            .into();
 
-        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) = escrow_data;
+        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) =
+            escrow_data;
 
         if status != symbol_short!("funded") {
-            panic!("Escrow not funded");
+            return Err(Error::InvalidState);
         }
 
-        // Transfer funds to seller (simplified)
         seller.require_auth();
 
-        let updated_escrow = (property_id, buyer, seller, total_amount, deposited_amount, symbol_short!("released"), created_at);
+        let updated_escrow = (
+            property_id,
+            buyer,
+            seller,
+            total_amount,
+            deposited_amount,
+            symbol_short!("released"),
+            created_at,
+        );
         escrows.set(escrow_id, updated_escrow.into());
         env.storage().instance().set(&escrow_key, &escrows);
+        Ok(())
     }
 
     /// Get escrow details
-    pub fn get_escrow(env: Env, escrow_id: u64) -> (u64, Address, Address, u128, u128, Symbol, u64) {
+    pub fn get_escrow(
+        env: Env,
+        escrow_id: u64,
+    ) -> Result<(u64, Address, Address, u128, u128, Symbol, u64), Error> {
         let escrow_key = symbol_short!("escrow");
-        let escrows: Map<u64, Val> = env.storage().instance().get(&escrow_key).unwrap();
-        escrows.get(escrow_id).unwrap().into()
+        let escrows: Map<u64, Val> = env
+            .storage()
+            .instance()
+            .get(&escrow_key)
+            .ok_or(Error::NotInitialized)?;
+        Ok(escrows.get(escrow_id).ok_or(Error::EscrowNotFound)?.into())
     }
 
     /// Get total escrow count
     pub fn escrow_count(env: Env) -> u64 {
-        env.storage().instance().get(&symbol_short!("escrow_count")).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&symbol_short!("escrow_count"))
+            .unwrap_or(0)
     }
 }


### PR DESCRIPTION
Closes #274, 
Closes #275, 
Closes #276, 
Closes #277

- **#274** escrow: replace all `panic!` with `Result<T, Error>` using `#[contracterror]` enum
- **#275** escrow: add `transfer_admin` function (admin-only)
- **#276** escrow + bridge: validate constructor params (zero amounts, buyer==seller, empty chains, invalid signature bounds, zero gas/timeout)
- **#277** bridge: replace hardcoded `100000`/`*100` gas constants in `estimate_gas_usage` with `config.gas_limit_per_bridge` and chain `gas_multiplier`