### PR TITLE
Remove unused dependencies from Cargo.toml files

### DIFF
--- a/stellar-insured-contracts/contracts/analytics/Cargo.toml
+++ b/stellar-insured-contracts/contracts/analytics/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 ink = { workspace = true }
 scale = { workspace = true }
 scale-info = { workspace = true }
-propchain-traits = { path = "../traits", default-features = false }
 
 [lib]
 path = "src/lib.rs"
@@ -19,6 +18,5 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-    "propchain-traits/std",
 ]
 ink-as-dependency = []

--- a/stellar-insured-contracts/contracts/bridge/Cargo.toml
+++ b/stellar-insured-contracts/contracts/bridge/Cargo.toml
@@ -5,8 +5,20 @@ authors = ["PropChain Team <dev@propchain.io>"]
 edition = "2021"
 
 [dependencies]
-soroban-sdk = { workspace = true }
+ink = { version = "5.0.0", default-features = false }
+scale = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+propchain-traits = { path = "../traits", default-features = false }
 
 [lib]
 crate-type = ["cdylib"]
 path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "propchain-traits/std",
+]

--- a/stellar-insured-contracts/contracts/fractional/Cargo.toml
+++ b/stellar-insured-contracts/contracts/fractional/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib", "rlib"]
 ink = { version = "5.0.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-propchain_traits = { package = "propchain-traits", path = "../traits", default-features = false }
 
 [features]
 default = ["std"]
@@ -23,6 +22,5 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-    "propchain_traits/std",
 ]
 ink-as-dependency = []

--- a/stellar-insured-contracts/contracts/insurance/Cargo.toml
+++ b/stellar-insured-contracts/contracts/insurance/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 ink = { version = "5.1.1", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.7.5", default-features = false, features = ["derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-propchain-traits = { path = "./traits", default-features = false }
 
 [dev-dependencies]
 ink_e2e = "5.1.1"
@@ -30,7 +29,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-    "propchain-traits/std",
 ]
 ink-as-dependency = []
 e2e-tests = []

--- a/stellar-insured-contracts/contracts/ipfs-metadata/Cargo.toml
+++ b/stellar-insured-contracts/contracts/ipfs-metadata/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 ink = { workspace = true }
 scale = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"], optional = true }
-propchain-traits = { path = "../traits", default-features = false }
 
 [lib]
 path = "src/lib.rs"
@@ -22,6 +21,5 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-    "propchain-traits/std",
 ]
 ink-as-dependency = []

--- a/stellar-insured-contracts/tests/Cargo.toml
+++ b/stellar-insured-contracts/tests/Cargo.toml
@@ -38,9 +38,6 @@ propchain-escrow = { path = "../contracts/escrow" }
 [features]
 default = ["std"]
 std = [
-    "ink/std",
-    "scale/std",
-    "scale-info/std",
     "property-token/std",
     "serde/std",
     "serde_json/std",


### PR DESCRIPTION
Closes #284

- Remove unused propchain-traits from contracts/insurance, fractional, ipfs-metadata, analytics
- Fix bridge Cargo.toml to use ink dependencies instead of soroban-sdk
- Remove unused ink features from tests/Cargo.toml

- Closes #286