### PR TITLE
Title: feat: make property-token contract upgrade-aware (#345)

### DIFF
--- a/stellar-insured-contracts/contracts/property-token/src/lib.rs
+++ b/stellar-insured-contracts/contracts/property-token/src/lib.rs
@@ -421,6 +421,20 @@ mod property_token {
             Ok(())
         }
 
+        /// Upgrades the contract code to the provided `code_hash`.
+        /// Only the admin can perform this operation.
+        #[ink(message)]
+        pub fn set_code_hash(&mut self, code_hash: Hash) -> Result<(), Error> {
+            let caller = self.env().caller();
+            if caller != self.admin {
+                return Err(Error::Unauthorized);
+            }
+            self.env()
+                .set_code_hash(&code_hash)
+                .map_err(|_| Error::InvalidRequest)?;
+            Ok(())
+        }
+
         #[ink(message)]
         pub fn total_shares(&self, token_id: TokenId) -> u128 {
             self.total_shares.get(token_id).unwrap_or(0)


### PR DESCRIPTION


Description:
This PR resolves #345 by introducing upgradeability to the `property-token` contract. 

**Changes Included:**
- Implemented the `set_code_hash` function, which is the standard `ink!` mechanism for contract upgrades.
- Added strict authorization checks to ensure that only the `admin` of the contract can perform an upgrade.
- Upgrading is achieved by replacing the WASM code hash at runtime, allowing the contract logic to evolve without losing its state or address.

This pattern ensures that the core contract logic can be securely migrated or patched in the future while maintaining all underlying asset states and ownership mappings.

Closed #345