### PR TITLE
fix(#346): introduce role-based access control (RBAC)

### DIFF
--- a/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
@@ -1,8 +1,11 @@
     impl PropertyInsurance {
         #[ink(constructor)]
         pub fn new(admin: AccountId) -> Self {
+            let mut role_manager = RoleManager::default();
+            role_manager.grant(admin, Role::Admin);
             Self {
                 admin,
+                role_manager,
                 policies: Mapping::default(),
                 policy_count: 0,
                 policyholder_policies: Mapping::default(),
@@ -65,7 +68,7 @@
             max_coverage_ratio: u32,
             reinsurance_threshold: u128,
         ) -> Result<u64, InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             
             // Input validation
             if name.is_empty() {
@@ -261,7 +264,7 @@
             vesting_duration_seconds: u64,
             early_withdrawal_penalty_bps: u32,
         ) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let mut pool = self.pools.get(&pool_id).ok_or(InsuranceError::PoolNotFound)?;
             pool.vesting_cliff_seconds = vesting_cliff_seconds;
             pool.vesting_duration_seconds = vesting_duration_seconds;
@@ -705,7 +708,7 @@
             valid_for_seconds: u64,
         ) -> Result<(), InsuranceError> {
             let caller = self.env().caller();
-            if caller != self.admin && !self.authorized_oracles.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -978,7 +981,7 @@
                 .get(&policy_id)
                 .ok_or(InsuranceError::PolicyNotFound)?;
 
-            if caller != policy.policyholder && caller != self.admin {
+            if caller != policy.policyholder && !self.role_manager.has_role(caller, Role::Admin) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1205,7 +1208,7 @@
                 return Err(InsuranceError::ContractPaused);
             }
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1281,7 +1284,7 @@
         ) -> Result<BatchClaimSummary, InsuranceError> {
             let caller = self.env().caller();
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1347,7 +1350,7 @@
         ) -> Result<BatchClaimSummary, InsuranceError> {
             let caller = self.env().caller();
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1543,7 +1546,9 @@
 
             // Verify caller is authorized (claimant, assessor, or admin)
             let is_authorized =
-                caller == claim.claimant || claim.assessor == Some(caller) || caller == self.admin;
+                caller == claim.claimant
+                    || claim.assessor == Some(caller)
+                    || self.role_manager.has_role(caller, Role::Admin);
 
             if !is_authorized {
                 return Err(InsuranceError::Unauthorized);
@@ -1610,8 +1615,7 @@
             let now = self.env().block_timestamp();
 
             // Verify caller is authorized (admin or authorized assessor)
-            let is_assessor = self.authorized_assessors.get(&caller).unwrap_or(false);
-            if caller != self.admin && !is_assessor {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1824,7 +1828,7 @@
             coverage_types: Vec<CoverageType>,
             duration_seconds: u64,
         ) -> Result<u64, InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
 
             let now = self.env().block_timestamp();
             let agreement_id = self.reinsurance_count + 1;
@@ -1961,7 +1965,7 @@
             data_points: u32,
         ) -> Result<u64, InsuranceError> {
             let caller = self.env().caller();
-            if caller != self.admin && !self.authorized_oracles.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1999,7 +2003,7 @@
             max_previous_claims: u32,
             min_risk_score: u32,
         ) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.pools
                 .get(&pool_id)
                 .ok_or(InsuranceError::PoolNotFound)?;
@@ -2022,34 +2026,68 @@
         // ADMIN / AUTHORITY MANAGEMENT
         // =====================================================================
 
-        /// Authorize an oracle address
+        /// Grant `role` to `account` (admin only). Emits `RoleGranted`. (#346)
+        #[ink(message)]
+        pub fn grant_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
+            self.ensure_role(Role::Admin)?;
+            self.role_manager.grant(account, role);
+            self.env().emit_event(RoleGranted {
+                account,
+                role,
+                granted_by: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Revoke `role` from `account` (admin only). Emits `RoleRevoked`. (#346)
+        #[ink(message)]
+        pub fn revoke_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
+            self.ensure_role(Role::Admin)?;
+            self.role_manager.revoke(account, role);
+            self.env().emit_event(RoleRevoked {
+                account,
+                role,
+                revoked_by: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Return `true` if `account` holds `role`. (#346)
+        #[ink(message)]
+        pub fn has_role(&self, account: AccountId, role: Role) -> bool {
+            self.role_manager.has_role(account, role)
+        }
+
+        /// Return all roles held by `account`. (#346)
+        #[ink(message)]
+        pub fn get_roles(&self, account: AccountId) -> Vec<Role> {
+            self.role_manager.roles_of(account)
+        }
+
+        /// Authorize an oracle address (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_oracle(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
-            self.authorized_oracles.insert(&oracle, &true);
-            Ok(())
+            self.grant_role(oracle, Role::Oracle)
         }
 
         /// Set oracle contract for parametric claims (admin only)
         #[ink(message)]
         pub fn set_oracle_contract(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.oracle_contract = Some(oracle);
             Ok(())
         }
 
-        /// Authorize a claims assessor
+        /// Authorize a claims assessor (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_assessor(&mut self, assessor: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
-            self.authorized_assessors.insert(&assessor, &true);
-            Ok(())
+            self.grant_role(assessor, Role::Assessor)
         }
 
         /// Update platform fee rate (admin only)
         #[ink(message)]
         pub fn set_platform_fee_rate(&mut self, rate: u32) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if rate > 1000 {
                 return Err(InsuranceError::InvalidParameters); // Max 10%
             }
@@ -2060,7 +2098,7 @@
         /// Update claim cooldown period (admin only)
         #[ink(message)]
         pub fn set_claim_cooldown(&mut self, period_seconds: u64) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.claim_cooldown_period = period_seconds;
             Ok(())
         }
@@ -2086,7 +2124,7 @@
         /// have elapsed and `execute_pause` is called (#301).
         #[ink(message)]
         pub fn propose_pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2107,7 +2145,7 @@
         /// delay has elapsed (#301).
         #[ink(message)]
         pub fn execute_pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let earliest = self.pending_pause_after
                 .ok_or(InsuranceError::InvalidParameters)?;
             if self.env().block_timestamp() < earliest {
@@ -2127,7 +2165,7 @@
         /// For non-emergency use, prefer `propose_pause` + `execute_pause`.
         #[ink(message)]
         pub fn pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2142,7 +2180,7 @@
         /// Unpause contract operations (admin only)
         #[ink(message)]
         pub fn unpause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if !self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2165,7 +2203,7 @@
         /// and a call to `execute_set_admin` (#301).
         #[ink(message)]
         pub fn propose_set_admin(&mut self, new_admin: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.pending_admin_after.is_some() {
                 return Err(InsuranceError::TimeLockPending);
             }
@@ -2185,7 +2223,7 @@
         /// time-lock delay has elapsed (#301).
         #[ink(message)]
         pub fn execute_set_admin(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let earliest = self.pending_admin_after
                 .ok_or(InsuranceError::InvalidParameters)?;
             if self.env().block_timestamp() < earliest {
@@ -2208,7 +2246,7 @@
         /// Cancel a pending admin proposal (admin only) (#301).
         #[ink(message)]
         pub fn cancel_pending_admin(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.pending_admin = None;
             self.pending_admin_after = None;
             Ok(())
@@ -2505,8 +2543,9 @@
                 pool.accumulated_reward_per_share.saturating_add(inc);
         }
 
-        fn ensure_admin(&self) -> Result<(), InsuranceError> {
-            if self.env().caller() != self.admin {
+        /// Check that the caller holds `role` (or Admin, which satisfies every role).
+        fn ensure_role(&self, role: Role) -> Result<(), InsuranceError> {
+            if !self.role_manager.has_role(self.env().caller(), role) {
                 return Err(InsuranceError::Unauthorized);
             }
             Ok(())

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
@@ -2190,3 +2190,134 @@
         );
         assert!(result.is_ok());
     }
+
+    // =========================================================================
+    // RBAC TESTS (#346)
+    // =========================================================================
+
+    #[ink::test]
+    fn test_admin_has_admin_role_after_init() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        assert!(contract.has_role(accounts.alice, crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_non_admin_does_not_have_admin_role() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        assert!(!contract.has_role(accounts.bob, crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_grant_role_assessor() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // alice (admin) grants bob the Assessor role
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .expect("grant_role failed");
+        assert!(contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_grant_role_oracle() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.charlie, crate::Role::Oracle)
+            .expect("grant_role failed");
+        assert!(contract.has_role(accounts.charlie, crate::Role::Oracle));
+    }
+
+    #[ink::test]
+    fn test_revoke_role() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        contract
+            .revoke_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        assert!(!contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_grant_role_unauthorized() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // bob (non-admin) tries to grant a role
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.grant_role(accounts.charlie, crate::Role::Assessor);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_revoke_role_unauthorized() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        // charlie (non-admin) tries to revoke bob's role
+        test::set_caller::<DefaultEnvironment>(accounts.charlie);
+        let result = contract.revoke_role(accounts.bob, crate::Role::Assessor);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_admin_role_satisfies_assessor_check() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // Admin implicitly satisfies every role check
+        assert!(contract.has_role(accounts.alice, crate::Role::Assessor));
+        assert!(contract.has_role(accounts.alice, crate::Role::Oracle));
+        assert!(contract.has_role(accounts.alice, crate::Role::Underwriter));
+    }
+
+    #[ink::test]
+    fn test_get_roles_returns_granted_roles() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        contract
+            .grant_role(accounts.bob, crate::Role::Oracle)
+            .unwrap();
+        let roles = contract.get_roles(accounts.bob);
+        assert!(roles.contains(&crate::Role::Assessor));
+        assert!(roles.contains(&crate::Role::Oracle));
+        assert!(!roles.contains(&crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_authorize_oracle_backwards_compat() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        assert!(contract.has_role(accounts.bob, crate::Role::Oracle));
+    }
+
+    #[ink::test]
+    fn test_authorize_assessor_backwards_compat() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_assessor(accounts.bob).unwrap();
+        assert!(contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_non_admin_cannot_create_pool() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.create_risk_pool(
+            "Unauthorized Pool".into(),
+            CoverageType::Fire,
+            8000,
+            500_000_000_000u128,
+        );
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }

--- a/stellar-insured-contracts/contracts/insurance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/lib.rs
@@ -11,11 +11,15 @@
 
 use ink::storage::Mapping;
 
+mod rbac;
+pub use rbac::{Role, RoleManager};
+
 /// Decentralized Property Insurance Platform
 #[ink::contract]
 mod propchain_insurance {
     use super::*;
     use ink::prelude::{string::String, vec::Vec};
+    use crate::{Role, RoleManager};
 
     // =========================================================================
     // ERROR TYPES
@@ -441,6 +445,9 @@ mod propchain_insurance {
     pub struct PropertyInsurance {
         admin: AccountId,
 
+        // Role-based access control
+        role_manager: RoleManager,
+
         // Policies
         policies: Mapping<u64, InsurancePolicy>,
         policy_count: u64,
@@ -815,6 +822,24 @@ mod propchain_insurance {
         #[ink(topic)]
         new_admin: AccountId,
         timestamp: u64,
+    }
+
+    /// Emitted when a role is granted to an account (#346)
+    #[ink(event)]
+    pub struct RoleGranted {
+        #[ink(topic)]
+        account: AccountId,
+        role: Role,
+        granted_by: AccountId,
+    }
+
+    /// Emitted when a role is revoked from an account (#346)
+    #[ink(event)]
+    pub struct RoleRevoked {
+        #[ink(topic)]
+        account: AccountId,
+        role: Role,
+        revoked_by: AccountId,
     }
 
     // =========================================================================

--- a/stellar-insured-contracts/contracts/insurance/src/rbac.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/rbac.rs
@@ -1,0 +1,91 @@
+//! Role-Based Access Control (RBAC) module for the insurance contract.
+//!
+//! Defines roles and provides helpers for permission checks.
+//! Addresses issue #346 – Missing Access Control Roles.
+
+use ink::prelude::vec::Vec;
+use ink::storage::Mapping;
+
+/// All roles recognised by the insurance contract.
+///
+/// Roles are additive: a caller may hold multiple roles simultaneously.
+/// `Admin` is the super-role and implicitly satisfies every other role check.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    scale::Encode,
+    scale::Decode,
+    ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Role {
+    /// Full administrative control (pool creation, pausing, admin transfer, …).
+    Admin,
+    /// Can review, approve, and reject claims.
+    Assessor,
+    /// Can submit oracle reports and verify parametric triggers.
+    Oracle,
+    /// Can underwrite (issue) policies on behalf of the platform.
+    Underwriter,
+    /// Regular policyholder – can submit claims and manage own policies.
+    Policyholder,
+}
+
+/// Compact on-chain role store.
+///
+/// Stored as a flat `Mapping<(AccountId, u8), bool>` where the `u8` is the
+/// discriminant of [`Role`], keeping storage layout simple and gas-efficient.
+#[derive(Default)]
+#[ink::storage_item]
+pub struct RoleManager {
+    /// `(account, role_discriminant) -> has_role`
+    roles: Mapping<(ink::primitives::AccountId, u8), bool>,
+}
+
+impl RoleManager {
+    /// Assign `role` to `account`.
+    pub fn grant(&mut self, account: ink::primitives::AccountId, role: Role) {
+        self.roles.insert(&(account, role as u8), &true);
+    }
+
+    /// Remove `role` from `account`.
+    pub fn revoke(&mut self, account: ink::primitives::AccountId, role: Role) {
+        self.roles.remove(&(account, role as u8));
+    }
+
+    /// Return `true` if `account` holds `role` **or** the `Admin` role.
+    pub fn has_role(&self, account: ink::primitives::AccountId, role: Role) -> bool {
+        // Admin satisfies every role check.
+        if role != Role::Admin
+            && self
+                .roles
+                .get(&(account, Role::Admin as u8))
+                .unwrap_or(false)
+        {
+            return true;
+        }
+        self.roles.get(&(account, role as u8)).unwrap_or(false)
+    }
+
+    /// Return all roles currently held by `account`.
+    pub fn roles_of(&self, account: ink::primitives::AccountId) -> Vec<Role> {
+        let all = [
+            Role::Admin,
+            Role::Assessor,
+            Role::Oracle,
+            Role::Underwriter,
+            Role::Policyholder,
+        ];
+        all.iter()
+            .filter(|&&r| {
+                self.roles
+                    .get(&(account, r as u8))
+                    .unwrap_or(false)
+            })
+            .copied()
+            .collect()
+    }
+}


### PR DESCRIPTION
- Add Role enum (Admin, Assessor, Oracle, Underwriter, Policyholder)
- Add RoleManager backed by Mapping<(AccountId, u8), bool>
- Replace single-level ensure_admin() with ensure_role(role)
- Add grant_role, revoke_role, has_role, get_roles public functions
- Keep authorize_oracle/authorize_assessor as backwards-compat wrappers
- Emit RoleGranted/RoleRevoked events
- Add 12 RBAC unit tests

closes #346 