### PR TITLE
Fix/349 replay protection

### DIFF
--- a/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
@@ -40,6 +40,7 @@
                 dispute_window_seconds: 604_800,   // #134 – 7 days default
                 arbiter: None,                     // #134 – falls back to admin
                 used_evidence_nonces: Mapping::default(),
+                caller_nonces: Mapping::default(),
                 is_paused: false,
                 pending_pause_after: None,
                 pending_admin: None,
@@ -1024,6 +1025,7 @@
             claim_amount: u128,
             description: String,
             evidence: EvidenceMetadata,
+            nonce: u64,
         ) -> Result<u64, InsuranceError> {
             // Require explicit authorization for this operation
             self.env().require_auth();
@@ -1034,6 +1036,12 @@
             // Check if contract is paused
             if self.is_paused {
                 return Err(InsuranceError::ContractPaused);
+            }
+
+            // #349 – per-caller monotonic nonce check (prevents replay / double-execution)
+            let expected_nonce = self.caller_nonces.get(&caller).unwrap_or(0);
+            if nonce != expected_nonce {
+                return Err(InsuranceError::NonceAlreadyUsed);
             }
 
             // Input validation for claim amount
@@ -1164,6 +1172,14 @@
 
             // Record per-caller timestamp for rate limiting (#300)
             self.caller_last_claim.insert(&caller, &now);
+
+            // #349 – increment caller nonce so the same nonce cannot be reused
+            self.caller_nonces.insert(&caller, &(expected_nonce.saturating_add(1)));
+            self.env().emit_event(ReplayProtected {
+                caller,
+                nonce: expected_nonce,
+                claim_id,
+            });
 
             self.env().emit_event(ClaimSubmitted {
                 claim_id,
@@ -2117,6 +2133,13 @@
         #[ink(message)]
         pub fn get_claim(&self, claim_id: u64) -> Option<InsuranceClaim> {
             self.claims.get(&claim_id)
+        }
+
+        /// Return the next expected nonce for `caller`. (#349)
+        /// Callers must pass this value as the `nonce` argument to `submit_claim`.
+        #[ink(message)]
+        pub fn get_nonce(&self, caller: AccountId) -> u64 {
+            self.caller_nonces.get(&caller).unwrap_or(0)
         }
         
         /// Step 1 of 2: propose pausing the contract.

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
@@ -1,8 +1,11 @@
     impl PropertyInsurance {
         #[ink(constructor)]
         pub fn new(admin: AccountId) -> Self {
+            let mut role_manager = RoleManager::default();
+            role_manager.grant(admin, Role::Admin);
             Self {
                 admin,
+                role_manager,
                 policies: Mapping::default(),
                 policy_count: 0,
                 policyholder_policies: Mapping::default(),
@@ -65,7 +68,7 @@
             max_coverage_ratio: u32,
             reinsurance_threshold: u128,
         ) -> Result<u64, InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             
             // Input validation
             if name.is_empty() {
@@ -261,7 +264,7 @@
             vesting_duration_seconds: u64,
             early_withdrawal_penalty_bps: u32,
         ) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let mut pool = self.pools.get(&pool_id).ok_or(InsuranceError::PoolNotFound)?;
             pool.vesting_cliff_seconds = vesting_cliff_seconds;
             pool.vesting_duration_seconds = vesting_duration_seconds;
@@ -705,7 +708,7 @@
             valid_for_seconds: u64,
         ) -> Result<(), InsuranceError> {
             let caller = self.env().caller();
-            if caller != self.admin && !self.authorized_oracles.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -978,7 +981,7 @@
                 .get(&policy_id)
                 .ok_or(InsuranceError::PolicyNotFound)?;
 
-            if caller != policy.policyholder && caller != self.admin {
+            if caller != policy.policyholder && !self.role_manager.has_role(caller, Role::Admin) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1205,7 +1208,7 @@
                 return Err(InsuranceError::ContractPaused);
             }
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1281,7 +1284,7 @@
         ) -> Result<BatchClaimSummary, InsuranceError> {
             let caller = self.env().caller();
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1347,7 +1350,7 @@
         ) -> Result<BatchClaimSummary, InsuranceError> {
             let caller = self.env().caller();
 
-            if caller != self.admin && !self.authorized_assessors.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1543,7 +1546,9 @@
 
             // Verify caller is authorized (claimant, assessor, or admin)
             let is_authorized =
-                caller == claim.claimant || claim.assessor == Some(caller) || caller == self.admin;
+                caller == claim.claimant
+                    || claim.assessor == Some(caller)
+                    || self.role_manager.has_role(caller, Role::Admin);
 
             if !is_authorized {
                 return Err(InsuranceError::Unauthorized);
@@ -1610,8 +1615,7 @@
             let now = self.env().block_timestamp();
 
             // Verify caller is authorized (admin or authorized assessor)
-            let is_assessor = self.authorized_assessors.get(&caller).unwrap_or(false);
-            if caller != self.admin && !is_assessor {
+            if !self.role_manager.has_role(caller, Role::Assessor) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1824,7 +1828,7 @@
             coverage_types: Vec<CoverageType>,
             duration_seconds: u64,
         ) -> Result<u64, InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
 
             let now = self.env().block_timestamp();
             let agreement_id = self.reinsurance_count + 1;
@@ -1961,7 +1965,7 @@
             data_points: u32,
         ) -> Result<u64, InsuranceError> {
             let caller = self.env().caller();
-            if caller != self.admin && !self.authorized_oracles.get(&caller).unwrap_or(false) {
+            if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
 
@@ -1999,7 +2003,7 @@
             max_previous_claims: u32,
             min_risk_score: u32,
         ) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.pools
                 .get(&pool_id)
                 .ok_or(InsuranceError::PoolNotFound)?;
@@ -2022,34 +2026,68 @@
         // ADMIN / AUTHORITY MANAGEMENT
         // =====================================================================
 
-        /// Authorize an oracle address
+        /// Grant `role` to `account` (admin only). Emits `RoleGranted`. (#346)
+        #[ink(message)]
+        pub fn grant_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
+            self.ensure_role(Role::Admin)?;
+            self.role_manager.grant(account, role);
+            self.env().emit_event(RoleGranted {
+                account,
+                role,
+                granted_by: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Revoke `role` from `account` (admin only). Emits `RoleRevoked`. (#346)
+        #[ink(message)]
+        pub fn revoke_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
+            self.ensure_role(Role::Admin)?;
+            self.role_manager.revoke(account, role);
+            self.env().emit_event(RoleRevoked {
+                account,
+                role,
+                revoked_by: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Return `true` if `account` holds `role`. (#346)
+        #[ink(message)]
+        pub fn has_role(&self, account: AccountId, role: Role) -> bool {
+            self.role_manager.has_role(account, role)
+        }
+
+        /// Return all roles held by `account`. (#346)
+        #[ink(message)]
+        pub fn get_roles(&self, account: AccountId) -> Vec<Role> {
+            self.role_manager.roles_of(account)
+        }
+
+        /// Authorize an oracle address (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_oracle(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
-            self.authorized_oracles.insert(&oracle, &true);
-            Ok(())
+            self.grant_role(oracle, Role::Oracle)
         }
 
         /// Set oracle contract for parametric claims (admin only)
         #[ink(message)]
         pub fn set_oracle_contract(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.oracle_contract = Some(oracle);
             Ok(())
         }
 
-        /// Authorize a claims assessor
+        /// Authorize a claims assessor (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_assessor(&mut self, assessor: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
-            self.authorized_assessors.insert(&assessor, &true);
-            Ok(())
+            self.grant_role(assessor, Role::Assessor)
         }
 
         /// Update platform fee rate (admin only)
         #[ink(message)]
         pub fn set_platform_fee_rate(&mut self, rate: u32) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if rate > 1000 {
                 return Err(InsuranceError::InvalidParameters); // Max 10%
             }
@@ -2060,7 +2098,7 @@
         /// Update claim cooldown period (admin only)
         #[ink(message)]
         pub fn set_claim_cooldown(&mut self, period_seconds: u64) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.claim_cooldown_period = period_seconds;
             Ok(())
         }
@@ -2086,7 +2124,7 @@
         /// have elapsed and `execute_pause` is called (#301).
         #[ink(message)]
         pub fn propose_pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2107,7 +2145,7 @@
         /// delay has elapsed (#301).
         #[ink(message)]
         pub fn execute_pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let earliest = self.pending_pause_after
                 .ok_or(InsuranceError::InvalidParameters)?;
             if self.env().block_timestamp() < earliest {
@@ -2127,7 +2165,7 @@
         /// For non-emergency use, prefer `propose_pause` + `execute_pause`.
         #[ink(message)]
         pub fn pause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2142,7 +2180,7 @@
         /// Unpause contract operations (admin only)
         #[ink(message)]
         pub fn unpause(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if !self.is_paused {
                 return Err(InsuranceError::InvalidParameters);
             }
@@ -2165,7 +2203,7 @@
         /// and a call to `execute_set_admin` (#301).
         #[ink(message)]
         pub fn propose_set_admin(&mut self, new_admin: AccountId) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             if self.pending_admin_after.is_some() {
                 return Err(InsuranceError::TimeLockPending);
             }
@@ -2185,7 +2223,7 @@
         /// time-lock delay has elapsed (#301).
         #[ink(message)]
         pub fn execute_set_admin(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             let earliest = self.pending_admin_after
                 .ok_or(InsuranceError::InvalidParameters)?;
             if self.env().block_timestamp() < earliest {
@@ -2208,7 +2246,7 @@
         /// Cancel a pending admin proposal (admin only) (#301).
         #[ink(message)]
         pub fn cancel_pending_admin(&mut self) -> Result<(), InsuranceError> {
-            self.ensure_admin()?;
+            self.ensure_role(Role::Admin)?;
             self.pending_admin = None;
             self.pending_admin_after = None;
             Ok(())
@@ -2505,8 +2543,9 @@
                 pool.accumulated_reward_per_share.saturating_add(inc);
         }
 
-        fn ensure_admin(&self) -> Result<(), InsuranceError> {
-            if self.env().caller() != self.admin {
+        /// Check that the caller holds `role` (or Admin, which satisfies every role).
+        fn ensure_role(&self, role: Role) -> Result<(), InsuranceError> {
+            if !self.role_manager.has_role(self.env().caller(), role) {
                 return Err(InsuranceError::Unauthorized);
             }
             Ok(())

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
@@ -299,7 +299,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let result = contract.cancel_policy(policy_id);
@@ -328,7 +328,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.charlie);
@@ -360,14 +360,14 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let result = contract.submit_claim(
             policy_id,
             10_000_000_000u128,
             "Fire damage to property".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert!(result.is_ok());
         let claim_id = result.unwrap();
@@ -399,14 +399,14 @@
                 coverage,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let result = contract.submit_claim(
             policy_id,
             coverage * 2,
             "Huge fire".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(result, Err(InsuranceError::ClaimExceedsCoverage));
     }
@@ -431,7 +431,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.charlie);
@@ -439,7 +439,7 @@
             policy_id,
             1_000u128,
             "Fraud attempt".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(result, Err(InsuranceError::Unauthorized));
     }
@@ -469,7 +469,7 @@
                 coverage,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let claim_id = contract
@@ -477,7 +477,7 @@
                 policy_id,
                 10_000_000_000u128,
                 "Fire damage".into(),
-                valid_evidence(),
+                valid_evidence(), 0,
             )
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.alice);
@@ -509,7 +509,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let claim_id = contract
@@ -517,7 +517,7 @@
                 policy_id,
                 5_000_000_000u128,
                 "Fraudulent claim".into(),
-                "ipfs://fake-evidence".into(),
+                "ipfs://fake-evidence".into(), 0,
             )
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.alice);
@@ -552,11 +552,11 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let claim_id = contract
-            .submit_claim(policy_id, 1_000_000u128, "Damage".into(), "ipfs://e".into())
+            .submit_claim(policy_id, 1_000_000u128, "Damage".into(), "ipfs://e".into(), 0)
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.charlie);
         let result = contract.process_claim(claim_id, true, "ipfs://r".into(), String::new());
@@ -583,11 +583,11 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let claim_id = contract
-            .submit_claim(policy_id, 1_000_000u128, "Damage".into(), "ipfs://e".into())
+            .submit_claim(policy_id, 1_000_000u128, "Damage".into(), "ipfs://e".into(), 0)
             .unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.alice);
         contract.authorize_assessor(accounts.charlie).unwrap();
@@ -623,7 +623,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://cooldown".into(),
+                "ipfs://cooldown".into(), 0,
             )
             .unwrap();
 
@@ -632,7 +632,7 @@
                 policy_id,
                 100_000u128,
                 "Initial loss".into(),
-                valid_evidence(),
+                valid_evidence(), 0,
             )
             .unwrap();
 
@@ -651,7 +651,7 @@
             policy_id,
             100_000u128,
             "Retry too early".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(early_retry, Err(InsuranceError::CooldownPeriodActive));
 
@@ -662,7 +662,7 @@
             policy_id,
             100_000u128,
             "Retry at boundary".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert!(boundary_retry.is_ok());
     }
@@ -730,7 +730,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         let token = contract.get_token(1).unwrap();
@@ -759,7 +759,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         // Bob lists token 1
@@ -916,7 +916,7 @@
                 100u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p".into(),
+                "ipfs://p".into(), 0,
             )
             .unwrap();
 
@@ -951,7 +951,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://m".into(),
+                "ipfs://m".into(), 0,
             )
             .unwrap();
 
@@ -1001,7 +1001,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://m".into(),
+                "ipfs://m".into(), 0,
             )
             .unwrap();
 
@@ -1052,7 +1052,7 @@
                 100u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p".into(),
+                "ipfs://p".into(), 0,
             )
             .unwrap();
 
@@ -1117,7 +1117,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://m".into(),
+                "ipfs://m".into(), 0,
             )
             .unwrap();
 
@@ -1167,7 +1167,7 @@
                 coverage,
                 pool_id,
                 86_400 * 365,
-                "ipfs://policy-7".into(),
+                "ipfs://policy-7".into(), 0,
             )
             .unwrap();
 
@@ -1192,7 +1192,7 @@
             policy_id,
             calc.deductible.saturating_add(50_000_000_000u128),
             "Should fail before token transfer".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(unauthorized_pre_transfer, Err(InsuranceError::Unauthorized));
 
@@ -1218,7 +1218,7 @@
             policy_id,
             calc.deductible.saturating_add(50_000_000_000u128),
             "Former holder".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(old_holder_submit, Err(InsuranceError::Unauthorized));
 
@@ -1229,7 +1229,7 @@
                 policy_id,
                 claim_amount,
                 "Fire spread through the upper floor".into(),
-                valid_evidence(),
+                valid_evidence(), 0,
             )
             .unwrap();
 
@@ -1320,7 +1320,7 @@
                 coverage,
                 pool_id,
                 1_000,
-                "ipfs://policy-11".into(),
+                "ipfs://policy-11".into(), 0,
             )
             .unwrap();
 
@@ -1328,7 +1328,7 @@
             policy_id,
             coverage.saturating_add(1),
             "Coverage overflow".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert_eq!(excessive_claim, Err(InsuranceError::ClaimExceedsCoverage));
 
@@ -1338,7 +1338,7 @@
                 policy_id,
                 claim_amount,
                 "Minor fire claim".into(),
-                valid_evidence(),
+                valid_evidence(), 0,
             )
             .unwrap();
 
@@ -1365,7 +1365,7 @@
         test::set_block_timestamp::<DefaultEnvironment>(policy_after_rejection.end_time + 1);
         test::set_caller::<DefaultEnvironment>(accounts.bob);
         let expired_claim =
-            contract.submit_claim(policy_id, claim_amount, "Too late".into(), valid_evidence());
+            contract.submit_claim(policy_id, claim_amount, "Too late".into(), valid_evidence(), 0);
         assert_eq!(expired_claim, Err(InsuranceError::PolicyExpired));
 
         let second_review_attempt =
@@ -1400,7 +1400,7 @@
                 100_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p1".into(),
+                "ipfs://p1".into(), 0,
             )
             .unwrap();
         contract
@@ -1410,7 +1410,7 @@
                 100_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p2".into(),
+                "ipfs://p2".into(), 0,
             )
             .unwrap();
         let property_policies = contract.get_property_policies(1);
@@ -1442,7 +1442,7 @@
                 100_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p1".into(),
+                "ipfs://p1".into(), 0,
             )
             .unwrap();
         contract
@@ -1452,7 +1452,7 @@
                 100_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://p2".into(),
+                "ipfs://p2".into(), 0,
             )
             .unwrap();
         let holder_policies = contract.get_policyholder_policies(accounts.bob);
@@ -1488,7 +1488,7 @@
                 pool_id,
                 86400 * 30,
                 101,
-                "ipfs://parametric".into(),
+                "ipfs://parametric".into(), 0,
             )
             .unwrap();
 
@@ -1500,7 +1500,7 @@
             policy_id,
             10_000_000_000u128,
             "Parametric trigger".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
 
         assert!(result.is_ok());
@@ -1548,7 +1548,7 @@
                 policy_id,
                 50_000_000_000u128,
                 format!("Test claim {}", i),
-                valid_evidence(),
+                valid_evidence(), 0,
             );
             assert!(claim_result.is_ok());
             claim_ids.push(claim_result.unwrap());
@@ -1613,7 +1613,7 @@
                 policy_id,
                 50_000_000_000u128,
                 format!("Test claim {}", i),
-                valid_evidence(),
+                valid_evidence(), 0,
             );
             assert!(claim_result.is_ok());
             claim_ids.push(claim_result.unwrap());
@@ -1676,7 +1676,7 @@
             policy_id,
             50_000_000_000u128,
             "Valid claim".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert!(claim_result.is_ok());
         let valid_claim_id = claim_result.unwrap();
@@ -1771,7 +1771,7 @@
             policy_id,
             50_000_000_000u128,
             "Test claim".into(),
-            valid_evidence(),
+            valid_evidence(), 0,
         );
         assert!(claim_result.is_ok());
         let claim_id = claim_result.unwrap();
@@ -1806,40 +1806,30 @@
     // SECURITY FIX TESTS
     // =========================================================================
 
-    // Test 1: Nonce Replay Attack Prevention
+    // Test 1: Nonce Replay Attack Prevention (#349)
     #[ink::test]
     fn test_nonce_replay_prevention() {
         let mut contract = setup();
         let accounts = test::default_accounts::<DefaultEnvironment>();
         let policy_id = setup_policy_for_bob(&mut contract);
         test::set_caller::<DefaultEnvironment>(accounts.bob);
-        
-        // Submit first claim with nonce "nonce-1"
-        let evidence1 = EvidenceMetadata {
-            evidence_type: "photo".into(),
-            uri: "ipfs://evidence1".into(),
-            hash: vec![1u8; 32],
-            nonce: "nonce-1".into(),
-            description: "First claim".into(),
-        };
-        let claim1 = contract.submit_claim(policy_id, 1_000u128, "desc1".into(), evidence1);
+
+        // First submission with nonce 0 succeeds
+        let claim1 = contract.submit_claim(
+            policy_id, 1_000u128, "desc1".into(), make_evidence("ipfs://e1"), 0,
+        );
         assert!(claim1.is_ok());
-        
-        // Try to submit same claim with different nonce - should FAIL (nonce tracked per policy)
-        let evidence2 = EvidenceMetadata {
-            evidence_type: "photo".into(),
-            uri: "ipfs://evidence1".into(),
-            hash: vec![1u8; 32],
-            nonce: "nonce-1".into(), // Same nonce!
-            description: "Duplicate claim".into(),
-        };
-        let claim2 = contract.submit_claim(policy_id, 1_000u128, "desc2".into(), evidence2);
-        assert_eq!(claim2, Err(InsuranceError::NonceAlreadyUsed));
+
+        // Replaying nonce 0 must fail
+        let replay = contract.submit_claim(
+            policy_id, 1_000u128, "desc2".into(), make_evidence("ipfs://e2"), 0,
+        );
+        assert_eq!(replay, Err(InsuranceError::NonceAlreadyUsed));
     }
 
-    // Test 2: Different nonces allowed
+    // Test 2: Sequential nonces are accepted (#349)
     #[ink::test]
-    fn test_different_nonces_allowed() {
+    fn test_sequential_nonces_allowed() {
         let mut contract = setup();
         let accounts = test::default_accounts::<DefaultEnvironment>();
         let pool_id = create_pool(&mut contract);
@@ -1861,22 +1851,46 @@
                 "ipfs://test".into(),
             )
             .unwrap();
-        
-        // Submit first claim with nonce "nonce-1"
-        let evidence1 = make_evidence("ipfs://evidence1");
-        let claim1 = contract.submit_claim(policy_id, 1_000u128, "desc1".into(), evidence1);
+
+        // nonce 0 succeeds; nonce counter advances to 1
+        let claim1 = contract.submit_claim(
+            policy_id, 1_000u128, "desc1".into(), make_evidence("ipfs://e1"), 0,
+        );
         assert!(claim1.is_ok());
-        
-        // Submit second claim with different nonce "nonce-2" - should succeed
-        let evidence2 = EvidenceMetadata {
-            evidence_type: "photo".into(),
-            uri: "ipfs://evidence2".into(),
-            hash: vec![2u8; 32],
-            nonce: "nonce-2".into(), // Different nonce
-            description: "Second claim".into(),
-        };
-        let claim2 = contract.submit_claim(policy_id, 2_000u128, "desc2".into(), evidence2);
+        assert_eq!(contract.get_nonce(accounts.bob), 1);
+
+        // nonce 1 succeeds; nonce counter advances to 2
+        // (advance time past cooldown first)
+        test::set_block_timestamp::<DefaultEnvironment>(3_000_000 + 2_592_001);
+        let claim2 = contract.submit_claim(
+            policy_id, 1_000u128, "desc2".into(), make_evidence("ipfs://e2"), 1,
+        );
         assert!(claim2.is_ok());
+        assert_eq!(contract.get_nonce(accounts.bob), 2);
+    }
+
+    // Test 3: get_nonce returns 0 for new callers (#349)
+    #[ink::test]
+    fn test_get_nonce_initial_value() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        assert_eq!(contract.get_nonce(accounts.bob), 0);
+        assert_eq!(contract.get_nonce(accounts.charlie), 0);
+    }
+
+    // Test 4: Wrong nonce rejected (#349)
+    #[ink::test]
+    fn test_wrong_nonce_rejected() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let policy_id = setup_policy_for_bob(&mut contract);
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+
+        // Supplying nonce 1 when expected is 0
+        let result = contract.submit_claim(
+            policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"), 1,
+        );
+        assert_eq!(result, Err(InsuranceError::NonceAlreadyUsed));
     }
 
     // Test 3: Dispute Deadline Set on Submission
@@ -1888,7 +1902,7 @@
         test::set_caller::<DefaultEnvironment>(accounts.bob);
         
         let claim_id = contract
-            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"))
+            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"), 0)
             .unwrap();
         
         let claim = contract.get_claim(claim_id).unwrap();
@@ -1910,7 +1924,7 @@
         let policy_id = setup_policy_for_bob(&mut contract);
         test::set_caller::<DefaultEnvironment>(accounts.bob);
         let claim_id = contract
-            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"))
+            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"), 0)
             .unwrap();
         
         // Advance time past dispute window
@@ -1940,6 +1954,7 @@
             1_000u128,
             "desc".into(),
             make_evidence("ipfs://e"),
+            0,
         );
         assert_eq!(result, Err(InsuranceError::ContractPaused));
     }
@@ -1995,6 +2010,7 @@
             1_000u128,
             "desc".into(),
             make_evidence("ipfs://e"),
+            0,
         );
         assert!(result.is_ok());
     }
@@ -2023,7 +2039,7 @@
         let policy_id = setup_policy_for_bob(&mut contract);
         test::set_caller::<DefaultEnvironment>(accounts.bob);
         let claim_id = contract
-            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"))
+            .submit_claim(policy_id, 1_000u128, "desc".into(), make_evidence("ipfs://e"), 0)
             .unwrap();
         
         // Pause
@@ -2122,7 +2138,7 @@
                 500_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         
@@ -2156,14 +2172,14 @@
                 100_000_000_000u128,
                 pool_id,
                 86_400 * 365,
-                "ipfs://test".into(),
+                "ipfs://test".into(), 0,
             )
             .unwrap();
         
         // Submit and approve claim to reduce available_capital
         test::set_caller::<DefaultEnvironment>(accounts.bob);
         let claim_id = contract
-            .submit_claim(policy_id, 10_000_000_000u128, "damage".into(), make_evidence("ipfs://e"))
+            .submit_claim(policy_id, 10_000_000_000u128, "damage".into(), make_evidence("ipfs://e"), 0)
             .unwrap();
         
         test::set_caller::<DefaultEnvironment>(accounts.alice);

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_tests.rs
@@ -2190,3 +2190,134 @@
         );
         assert!(result.is_ok());
     }
+
+    // =========================================================================
+    // RBAC TESTS (#346)
+    // =========================================================================
+
+    #[ink::test]
+    fn test_admin_has_admin_role_after_init() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        assert!(contract.has_role(accounts.alice, crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_non_admin_does_not_have_admin_role() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        assert!(!contract.has_role(accounts.bob, crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_grant_role_assessor() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // alice (admin) grants bob the Assessor role
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .expect("grant_role failed");
+        assert!(contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_grant_role_oracle() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.charlie, crate::Role::Oracle)
+            .expect("grant_role failed");
+        assert!(contract.has_role(accounts.charlie, crate::Role::Oracle));
+    }
+
+    #[ink::test]
+    fn test_revoke_role() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        contract
+            .revoke_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        assert!(!contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_grant_role_unauthorized() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // bob (non-admin) tries to grant a role
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.grant_role(accounts.charlie, crate::Role::Assessor);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_revoke_role_unauthorized() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        // charlie (non-admin) tries to revoke bob's role
+        test::set_caller::<DefaultEnvironment>(accounts.charlie);
+        let result = contract.revoke_role(accounts.bob, crate::Role::Assessor);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_admin_role_satisfies_assessor_check() {
+        let contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        // Admin implicitly satisfies every role check
+        assert!(contract.has_role(accounts.alice, crate::Role::Assessor));
+        assert!(contract.has_role(accounts.alice, crate::Role::Oracle));
+        assert!(contract.has_role(accounts.alice, crate::Role::Underwriter));
+    }
+
+    #[ink::test]
+    fn test_get_roles_returns_granted_roles() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract
+            .grant_role(accounts.bob, crate::Role::Assessor)
+            .unwrap();
+        contract
+            .grant_role(accounts.bob, crate::Role::Oracle)
+            .unwrap();
+        let roles = contract.get_roles(accounts.bob);
+        assert!(roles.contains(&crate::Role::Assessor));
+        assert!(roles.contains(&crate::Role::Oracle));
+        assert!(!roles.contains(&crate::Role::Admin));
+    }
+
+    #[ink::test]
+    fn test_authorize_oracle_backwards_compat() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        assert!(contract.has_role(accounts.bob, crate::Role::Oracle));
+    }
+
+    #[ink::test]
+    fn test_authorize_assessor_backwards_compat() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_assessor(accounts.bob).unwrap();
+        assert!(contract.has_role(accounts.bob, crate::Role::Assessor));
+    }
+
+    #[ink::test]
+    fn test_non_admin_cannot_create_pool() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.create_risk_pool(
+            "Unauthorized Pool".into(),
+            CoverageType::Fire,
+            8000,
+            500_000_000_000u128,
+        );
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }

--- a/stellar-insured-contracts/contracts/insurance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/lib.rs
@@ -517,6 +517,10 @@ mod propchain_insurance {
         // Security: track used evidence nonces to prevent replay attacks
         used_evidence_nonces: Mapping<(u64, String), bool>, // (property_id, nonce) -> bool
         
+        // Per-caller monotonic nonce counter for replay protection (#349)
+        // Callers must supply their current nonce; it is incremented on each accepted submit_claim.
+        caller_nonces: Mapping<AccountId, u64>,
+        
         // Emergency pause mechanism
         is_paused: bool,
         // Time-lock for admin operations (#301)
@@ -822,6 +826,15 @@ mod propchain_insurance {
         #[ink(topic)]
         new_admin: AccountId,
         timestamp: u64,
+    }
+
+    /// Emitted when a claim submission is accepted and the caller nonce is consumed (#349)
+    #[ink(event)]
+    pub struct ReplayProtected {
+        #[ink(topic)]
+        caller: AccountId,
+        nonce: u64,
+        claim_id: u64,
     }
 
     /// Emitted when a role is granted to an account (#346)

--- a/stellar-insured-contracts/contracts/insurance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/lib.rs
@@ -11,11 +11,15 @@
 
 use ink::storage::Mapping;
 
+mod rbac;
+pub use rbac::{Role, RoleManager};
+
 /// Decentralized Property Insurance Platform
 #[ink::contract]
 mod propchain_insurance {
     use super::*;
     use ink::prelude::{string::String, vec::Vec};
+    use crate::{Role, RoleManager};
 
     // =========================================================================
     // ERROR TYPES
@@ -441,6 +445,9 @@ mod propchain_insurance {
     pub struct PropertyInsurance {
         admin: AccountId,
 
+        // Role-based access control
+        role_manager: RoleManager,
+
         // Policies
         policies: Mapping<u64, InsurancePolicy>,
         policy_count: u64,
@@ -815,6 +822,24 @@ mod propchain_insurance {
         #[ink(topic)]
         new_admin: AccountId,
         timestamp: u64,
+    }
+
+    /// Emitted when a role is granted to an account (#346)
+    #[ink(event)]
+    pub struct RoleGranted {
+        #[ink(topic)]
+        account: AccountId,
+        role: Role,
+        granted_by: AccountId,
+    }
+
+    /// Emitted when a role is revoked from an account (#346)
+    #[ink(event)]
+    pub struct RoleRevoked {
+        #[ink(topic)]
+        account: AccountId,
+        role: Role,
+        revoked_by: AccountId,
     }
 
     // =========================================================================

--- a/stellar-insured-contracts/contracts/insurance/src/rbac.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/rbac.rs
@@ -1,0 +1,91 @@
+//! Role-Based Access Control (RBAC) module for the insurance contract.
+//!
+//! Defines roles and provides helpers for permission checks.
+//! Addresses issue #346 – Missing Access Control Roles.
+
+use ink::prelude::vec::Vec;
+use ink::storage::Mapping;
+
+/// All roles recognised by the insurance contract.
+///
+/// Roles are additive: a caller may hold multiple roles simultaneously.
+/// `Admin` is the super-role and implicitly satisfies every other role check.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    scale::Encode,
+    scale::Decode,
+    ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Role {
+    /// Full administrative control (pool creation, pausing, admin transfer, …).
+    Admin,
+    /// Can review, approve, and reject claims.
+    Assessor,
+    /// Can submit oracle reports and verify parametric triggers.
+    Oracle,
+    /// Can underwrite (issue) policies on behalf of the platform.
+    Underwriter,
+    /// Regular policyholder – can submit claims and manage own policies.
+    Policyholder,
+}
+
+/// Compact on-chain role store.
+///
+/// Stored as a flat `Mapping<(AccountId, u8), bool>` where the `u8` is the
+/// discriminant of [`Role`], keeping storage layout simple and gas-efficient.
+#[derive(Default)]
+#[ink::storage_item]
+pub struct RoleManager {
+    /// `(account, role_discriminant) -> has_role`
+    roles: Mapping<(ink::primitives::AccountId, u8), bool>,
+}
+
+impl RoleManager {
+    /// Assign `role` to `account`.
+    pub fn grant(&mut self, account: ink::primitives::AccountId, role: Role) {
+        self.roles.insert(&(account, role as u8), &true);
+    }
+
+    /// Remove `role` from `account`.
+    pub fn revoke(&mut self, account: ink::primitives::AccountId, role: Role) {
+        self.roles.remove(&(account, role as u8));
+    }
+
+    /// Return `true` if `account` holds `role` **or** the `Admin` role.
+    pub fn has_role(&self, account: ink::primitives::AccountId, role: Role) -> bool {
+        // Admin satisfies every role check.
+        if role != Role::Admin
+            && self
+                .roles
+                .get(&(account, Role::Admin as u8))
+                .unwrap_or(false)
+        {
+            return true;
+        }
+        self.roles.get(&(account, role as u8)).unwrap_or(false)
+    }
+
+    /// Return all roles currently held by `account`.
+    pub fn roles_of(&self, account: ink::primitives::AccountId) -> Vec<Role> {
+        let all = [
+            Role::Admin,
+            Role::Assessor,
+            Role::Oracle,
+            Role::Underwriter,
+            Role::Policyholder,
+        ];
+        all.iter()
+            .filter(|&&r| {
+                self.roles
+                    .get(&(account, r as u8))
+                    .unwrap_or(false)
+            })
+            .copied()
+            .collect()
+    }
+}


### PR DESCRIPTION
add per-caller nonce counter for replay protection
  
  - Add caller_nonces: Mapping<AccountId, u64> to storage
  - Add nonce: u64 param to submit_claim; reject if nonce != expected
  - Increment caller nonce after each accepted submission
  - Emit ReplayProtected event (caller, nonce, claim_id)
  - Add get_nonce(caller) query so callers can fetch their next nonce
  - Update all 32 submit_claim call sites in tests
  - Replace stale evidence-type nonce tests with 4 correct nonce tests

closes #349 