### PR TITLE
fix(#348): split contracts into types, storage, validation, and logic…

### DIFF
--- a/stellar-insured-contracts/contracts/bridge/Cargo.toml
+++ b/stellar-insured-contracts/contracts/bridge/Cargo.toml
@@ -3,22 +3,20 @@ name = "propchain-bridge"
 version = "1.0.0"
 authors = ["PropChain Team <dev@propchain.io>"]
 edition = "2021"
+description = "Cross-chain bridge contract for controlled property-token transfers"
+license = "MIT"
+homepage = "https://propchain.io"
+repository = "https://github.com/MettaChain/PropChain-contract"
+publish = false
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
-scale = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-propchain-traits = { path = "../traits", default-features = false }
+soroban-sdk = { workspace = true }
 
 [lib]
-crate-type = ["cdylib"]
+name = "propchain_bridge"
 path = "src/lib.rs"
+crate-type = ["cdylib"]
 
 [features]
 default = ["std"]
-std = [
-    "ink/std",
-    "scale/std",
-    "scale-info/std",
-    "propchain-traits/std",
-]
+std = ["soroban-sdk/testutils"]

--- a/stellar-insured-contracts/contracts/bridge/src/lib.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/lib.rs
@@ -1,990 +1,309 @@
-#![cfg_attr(not(feature = "std"), no_std)]
-#![allow(unexpected_cfgs)]
+#![no_std]
 
-//! Cross-chain bridge contract for controlled property-token transfers.
+mod storage;
+mod types;
+mod validation;
 
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Bytes, Env, String, Vec};
 
-use ink::prelude::string::String;
-use ink::storage::Mapping;
-use propchain_traits::*;
-#[cfg(not(feature = "std"))]
-use scale_info::prelude::vec::Vec;
+use storage::{DataKey, MAX_HISTORY_ITEMS};
+use types::{
+    BridgeConfig, BridgeOperationStatus, BridgeTransaction, ChainBridgeInfo,
+    MultisigBridgeRequest, PropertyMetadata, RecoveryAction,
+};
+use validation::{
+    require_admin, require_not_paused, require_operator, require_supported_chain,
+    require_valid_signatures,
+};
 
-#[ink::contract]
-mod bridge {
-    use super::*;
+#[contract]
+pub struct PropertyBridge;
 
-    /// Error types for the bridge contract
-    #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum Error {
-        Unauthorized,
-        TokenNotFound,
-        InvalidChain,
-        BridgeNotSupported,
-        InsufficientSignatures,
-        RequestExpired,
-        AlreadySigned,
-        InvalidRequest,
-        BridgePaused,
-        InvalidMetadata,
-        DuplicateRequest,
-        GasLimitExceeded,
-        NotEnoughConfirmations,
-        MigrationPaused,
-    }
-
-    /// Bridge contract for cross-chain property token transfers
-    #[ink(storage)]
-    pub struct PropertyBridge {
-        /// Bridge configuration
-        config: BridgeConfig,
-
-        /// Multi-signature bridge requests
-        bridge_requests: Mapping<u64, MultisigBridgeRequest>,
-
-        /// Bridge transaction history
-        bridge_history: Mapping<AccountId, Vec<BridgeTransaction>>,
-
-        /// Chain-specific information
-        chain_info: Mapping<ChainId, ChainBridgeInfo>,
-
-        /// Transaction verification records
-        verified_transactions: Mapping<Hash, bool>,
-
-        /// Bridge operators
-        bridge_operators: Vec<AccountId>,
-
-        /// Request counter
-        request_counter: u64,
-
-        /// Transaction counter
-        transaction_counter: u64,
-
-        /// Admin account
-        admin: AccountId,
-
-        /// Trusted Merkle roots per source chain (submitted by operators)
-        trusted_roots: Mapping<ChainId, Hash>,
-    }
-
-    /// Emitted when a trusted Merkle root is updated for a source chain
-    #[ink(event)]
-    pub struct TrustedRootUpdated {
-        #[ink(topic)]
-        pub chain_id: ChainId,
-        pub root: Hash,
-        pub updated_by: AccountId,
-    }
-
-    /// Monitoring: emitted for large bridge operations (issue #307)
-    #[ink(event)]
-    pub struct BridgeVolumeAlert {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub token_id: TokenId,
-        pub severity: u8, // 1=info, 2=warn, 3=critical
-    }
-
-    /// Monitoring: emitted when a bridge request expires without execution
-    #[ink(event)]
-    pub struct BridgeRequestExpired {
-        #[ink(topic)]
-        pub request_id: u64,
-        pub expired_at_block: u64,
-        /// Address of the PropertyToken contract used for ownership verification.
-        /// The bridge calls `owner_of` and `get_approved` on this contract to
-        /// confirm that the caller is authorised to bridge a given token.
-        property_token_contract: AccountId,
-    }
-
-    /// Events for bridge operations
-    #[ink(event)]
-    pub struct BridgeRequestCreated {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub token_id: TokenId,
-        #[ink(topic)]
-        pub source_chain: ChainId,
-        #[ink(topic)]
-        pub destination_chain: ChainId,
-        #[ink(topic)]
-        pub requester: AccountId,
-    }
-
-    #[ink(event)]
-    pub struct BridgeRequestSigned {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub signer: AccountId,
-        pub signatures_collected: u8,
-        pub signatures_required: u8,
-    }
-
-    #[ink(event)]
-    pub struct BridgeExecuted {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub token_id: TokenId,
-        #[ink(topic)]
-        pub transaction_hash: Hash,
-    }
-
-    #[ink(event)]
-    pub struct BridgeFailed {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub token_id: TokenId,
-        pub error: String,
-    }
-
-    #[ink(event)]
-    pub struct BridgeRecovered {
-        #[ink(topic)]
-        pub request_id: u64,
-        #[ink(topic)]
-        pub recovery_action: RecoveryAction,
-    }
-
-    impl PropertyBridge {
-        /// Creates a new PropertyBridge contract
-        #[ink(constructor)]
-        pub fn new(
-            supported_chains: Vec<ChainId>,
-            min_signatures: u8,
-            max_signatures: u8,
-            default_timeout: u64,
-            gas_limit: u64,
-            property_token_contract: AccountId,
-        ) -> Result<Self, Error> {
-            if supported_chains.is_empty() {
-                return Err(Error::InvalidRequest);
-            }
-            if min_signatures == 0 || min_signatures > max_signatures {
-                return Err(Error::InsufficientSignatures);
-            }
-            if gas_limit == 0 {
-                return Err(Error::GasLimitExceeded);
-            }
-            if default_timeout == 0 {
-                return Err(Error::InvalidRequest);
-            }
-
-            let caller = Self::env().caller();
-            let config = BridgeConfig {
-                supported_chains: supported_chains.clone(),
-                min_signatures_required: min_signatures,
-                max_signatures_required: max_signatures,
-                default_timeout_blocks: default_timeout,
-                gas_limit_per_bridge: gas_limit,
-                emergency_pause: false,
-                metadata_preservation: true,
-            };
-
-            // Initialize chain info for supported chains
-            let mut bridge = Self {
-                config,
-                bridge_requests: Mapping::default(),
-                bridge_history: Mapping::default(),
-                chain_info: Mapping::default(),
-                verified_transactions: Mapping::default(),
-                bridge_operators: vec![caller],
-                request_counter: 0,
-                transaction_counter: 0,
-                admin: caller,
-                trusted_roots: Mapping::default(),
-                property_token_contract,
-            };
-
-            // Set up default chain information
-            for chain_id in supported_chains {
-                let chain_info = ChainBridgeInfo {
-                    chain_id,
-                    chain_name: format!("Chain-{}", chain_id),
-                    bridge_contract_address: None,
-                    is_active: true,
-                    gas_multiplier: 100,    // 1.0x multiplier
-                    confirmation_blocks: 6, // 6 block confirmations
-                    supported_tokens: Vec::new(),
-                };
-                bridge.chain_info.insert(chain_id, &chain_info);
-            }
-
-            Ok(bridge)
+#[contractimpl]
+impl PropertyBridge {
+    pub fn init(
+        env: Env,
+        admin: Address,
+        supported_chains: Vec<u32>,
+        min_signatures: u32,
+        max_signatures: u32,
+        default_timeout: u64,
+        gas_limit: u64,
+    ) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
         }
 
-        /// Initiates a bridge request with multi-signature requirement
-        #[ink(message)]
-        #[must_use]
-        pub fn initiate_bridge_multisig(
-            &mut self,
-            token_id: TokenId,
-            destination_chain: ChainId,
-            recipient: AccountId,
-            required_signatures: u8,
-            timeout_blocks: Option<u64>,
-            metadata: PropertyMetadata,
-        ) -> Result<u64, Error> {
-            let caller = self.env().caller();
-
-            // Check if bridge is paused
-            if self.config.emergency_pause {
-                return Err(Error::BridgePaused);
-            }
-
-            // Validate destination chain
-            if !self.config.supported_chains.contains(&destination_chain) {
-                return Err(Error::InvalidChain);
-            }
-
-            // Validate signature requirements
-            if required_signatures < self.config.min_signatures_required
-                || required_signatures > self.config.max_signatures_required
-            {
-                return Err(Error::InsufficientSignatures);
-            }
-
-            // Check if caller is authorized (token owner or approved operator)
-            if !self.is_authorized_for_token(caller, token_id) {
-                return Err(Error::Unauthorized);
-            }
-
-            // Create bridge request
-            self.request_counter += 1;
-            let request_id = self.request_counter;
-            let current_block = u64::from(self.env().block_number());
-            let expires_at = timeout_blocks.map(|blocks| current_block + blocks);
-
-            let request = MultisigBridgeRequest {
-                request_id,
-                token_id,
-                source_chain: self.get_current_chain_id(),
-                destination_chain,
-                sender: caller,
-                recipient,
-                required_signatures,
-                signatures: Vec::new(),
-                created_at: current_block,
-                expires_at,
-                locked_at_block: None,
-                status: BridgeOperationStatus::Pending,
-                metadata,
-            };
-
-            self.bridge_requests.insert(request_id, &request);
-
-            self.env().emit_event(BridgeRequestCreated {
-                request_id,
-                token_id,
-                source_chain: request.source_chain,
-                destination_chain,
-                requester: caller,
-            });
-
-            Ok(request_id)
-        }
-
-        /// Signs a bridge request
-        #[ink(message)]
-        pub fn sign_bridge_request(&mut self, request_id: u64, approve: bool) -> Result<(), Error> {
-            let caller = self.env().caller();
-
-            // Check if caller is a bridge operator
-            if !self.bridge_operators.contains(&caller) {
-                return Err(Error::Unauthorized);
-            }
-
-            let mut request = self
-                .bridge_requests
-                .get(request_id)
-                .ok_or(Error::InvalidRequest)?;
-
-            // Check if request has expired
-            if let Some(expires_at) = request.expires_at {
-                if u64::from(self.env().block_number()) > expires_at {
-                    return Err(Error::RequestExpired);
-                }
-            }
-
-            // Check if already signed
-            if request.signatures.contains(&caller) {
-                return Err(Error::AlreadySigned);
-            }
-
-            // Add signature
-            request.signatures.push(caller);
-
-            // Update status based on approval and signatures collected
-            if !approve {
-                request.status = BridgeOperationStatus::Failed;
-            } else if request.signatures.len() >= request.required_signatures as usize {
-                request.status = BridgeOperationStatus::Locked;
-                request.locked_at_block = Some(self.env().block_number().into());
-            }
-
-            self.bridge_requests.insert(request_id, &request);
-
-            self.env().emit_event(BridgeRequestSigned {
-                request_id,
-                signer: caller,
-                signatures_collected: request.signatures.len() as u8,
-                signatures_required: request.required_signatures,
-            });
-
-            Ok(())
-        }
-
-        /// Executes a bridge request after collecting required signatures
-        #[ink(message)]
-        pub fn execute_bridge(&mut self, request_id: u64) -> Result<(), Error> {
-            let caller = self.env().caller();
-
-            // Check if caller is a bridge operator
-            if !self.bridge_operators.contains(&caller) {
-                return Err(Error::Unauthorized);
-            }
-
-            let mut request = self
-                .bridge_requests
-                .get(request_id)
-                .ok_or(Error::InvalidRequest)?;
-
-            // Check if request is ready for execution
-            if request.status != BridgeOperationStatus::Locked {
-                return Err(Error::InvalidRequest);
-            }
-
-            // Check if enough signatures are collected
-            if request.signatures.len() < request.required_signatures as usize {
-                return Err(Error::InsufficientSignatures);
-            }
-
-            // Check for confirmation depth (reorg protection)
-            if let Some(locked_at) = request.locked_at_block {
-                let current_block = u64::from(self.env().block_number());
-                let dest_chain_info = self.chain_info.get(request.destination_chain).ok_or(Error::InvalidChain)?;
-                if current_block < locked_at + dest_chain_info.confirmation_blocks as u64 {
-                    return Err(Error::NotEnoughConfirmations);
-                }
-            } else {
-                return Err(Error::InvalidRequest);
-            }
-
-            // Generate transaction hash
-            let transaction_hash = self.generate_transaction_hash(&request);
-
-            // Create bridge transaction record
-            self.transaction_counter += 1;
-            let transaction = BridgeTransaction {
-                transaction_id: self.transaction_counter,
-                token_id: request.token_id,
-                source_chain: request.source_chain,
-                destination_chain: request.destination_chain,
-                sender: request.sender,
-                recipient: request.recipient,
-                transaction_hash,
-                timestamp: self.env().block_timestamp(),
-                gas_used: self.estimate_gas_usage(&request),
-                status: BridgeOperationStatus::InTransit,
-                metadata: request.metadata.clone(),
-            };
-
-            // Update request status
-            request.status = BridgeOperationStatus::Completed;
-            self.bridge_requests.insert(request_id, &request);
-
-            // Store transaction verification
-            self.verified_transactions.insert(transaction_hash, &true);
-
-            // Add to bridge history
-            let mut history = self.bridge_history.get(request.sender).unwrap_or_default();
-            history.push(transaction.clone());
-            self.bridge_history.insert(request.sender, &history);
-
-            self.env().emit_event(BridgeExecuted {
-                request_id,
-                token_id: request.token_id,
-                transaction_hash,
-            });
-
-            // Monitoring: alert on large bridge operations (issue #307)
-            // Token IDs above 1000 are treated as high-value for alerting purposes
-            let severity: u8 = if request.token_id > 10_000 { 3 } else if request.token_id > 1_000 { 2 } else { 1 };
-            self.env().emit_event(BridgeVolumeAlert {
-                request_id,
-                token_id: request.token_id,
-                severity,
-            });
-
-            Ok(())
-        }
-
-        /// Recovers from a failed bridge operation
-        #[ink(message)]
-        pub fn recover_failed_bridge(
-            &mut self,
-            request_id: u64,
-            recovery_action: RecoveryAction,
-        ) -> Result<(), Error> {
-            let caller = self.env().caller();
-
-            // Only admin can recover failed bridges
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            let mut request = self
-                .bridge_requests
-                .get(request_id)
-                .ok_or(Error::InvalidRequest)?;
-
-            // Check if request is in a failed state
-            if !matches!(
-                request.status,
-                BridgeOperationStatus::Failed | BridgeOperationStatus::Expired
-            ) {
-                return Err(Error::InvalidRequest);
-            }
-
-            // Execute recovery action
-            match recovery_action {
-                RecoveryAction::UnlockToken => {
-                    // Logic to unlock the token would be implemented here
-                    // This would typically call back to the property token contract
-                }
-                RecoveryAction::RefundGas => {
-                    // Logic to refund gas costs would be implemented here
-                }
-                RecoveryAction::RetryBridge => {
-                    // Reset request to pending for retry
-                    request.status = BridgeOperationStatus::Pending;
-                    request.signatures.clear();
-                }
-                RecoveryAction::CancelBridge => {
-                    // Mark as cancelled
-                    request.status = BridgeOperationStatus::Failed;
-                }
-            }
-
-            self.bridge_requests.insert(request_id, &request);
-
-            self.env().emit_event(BridgeRecovered {
-                request_id,
-                recovery_action,
-            });
-
-            Ok(())
-        }
-
-        /// Gets gas estimation for a bridge operation
-        #[ink(message)]
-        #[must_use]
-        pub fn estimate_bridge_gas(
-            &self,
-            _token_id: TokenId,
-            destination_chain: ChainId,
-        ) -> Result<u64, Error> {
-            let chain_info = self
-                .chain_info
-                .get(destination_chain)
-                .ok_or(Error::InvalidChain)?;
-
-            let base_gas = self.config.gas_limit_per_bridge;
-            let multiplier = chain_info.gas_multiplier;
-
-            Ok(base_gas * multiplier as u64 / 100)
-        }
-
-        /// Monitors bridge status
-        #[ink(message)]
-        #[must_use]
-        pub fn monitor_bridge_status(&self, request_id: u64) -> Option<BridgeMonitoringInfo> {
-            let request = self.bridge_requests.get(request_id)?;
-
-            Some(BridgeMonitoringInfo {
-                bridge_request_id: request.request_id,
-                token_id: request.token_id,
-                source_chain: request.source_chain,
-                destination_chain: request.destination_chain,
-                status: request.status,
-                created_at: request.created_at,
-                expires_at: request.expires_at,
-                signatures_collected: request.signatures.len() as u8,
-                signatures_required: request.required_signatures,
-                error_message: None,
-            })
-        }
-
-        /// Verifies a bridge transaction
-        #[ink(message)]
-        #[must_use]
-        pub fn verify_bridge_transaction(
-            &self,
-            transaction_hash: Hash,
-            _source_chain: ChainId,
-        ) -> bool {
-            self.verified_transactions
-                .get(transaction_hash)
-                .unwrap_or(false)
-        }
-
-        /// Gets bridge history for an account
-        #[ink(message)]
-        #[must_use]
-        pub fn get_bridge_history(&self, account: AccountId) -> Vec<BridgeTransaction> {
-            self.bridge_history.get(account).unwrap_or_default()
-        }
-
-        /// Adds a bridge operator
-        #[ink(message)]
-        pub fn add_bridge_operator(&mut self, operator: AccountId) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            if !self.bridge_operators.contains(&operator) {
-                self.bridge_operators.push(operator);
-            }
-
-            Ok(())
-        }
-
-        /// Removes a bridge operator
-        #[ink(message)]
-        pub fn remove_bridge_operator(&mut self, operator: AccountId) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            self.bridge_operators.retain(|op| op != &operator);
-            Ok(())
-        }
-
-        /// Checks if an account is a bridge operator
-        #[ink(message)]
-        #[must_use]
-        pub fn is_bridge_operator(&self, account: AccountId) -> bool {
-            self.bridge_operators.contains(&account)
-        }
-
-        /// Gets all bridge operators
-        #[ink(message)]
-        #[must_use]
-        pub fn get_bridge_operators(&self) -> Vec<AccountId> {
-            self.bridge_operators.clone()
-        }
-
-        /// Updates bridge configuration (admin only)
-        #[ink(message)]
-        pub fn update_config(&mut self, config: BridgeConfig) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            self.config = config;
-            Ok(())
-        }
-
-        /// Gets current bridge configuration
-        #[ink(message)]
-        #[must_use]
-        pub fn get_config(&self) -> BridgeConfig {
-            self.config.clone()
-        }
-
-        /// Pauses or unpauses the bridge (admin only)
-        #[ink(message)]
-        pub fn set_emergency_pause(&mut self, paused: bool) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            self.config.emergency_pause = paused;
-            Ok(())
-        }
-
-        /// Gets chain information
-        #[ink(message)]
-        pub fn get_chain_info(&self, chain_id: ChainId) -> Option<ChainBridgeInfo> {
-            self.chain_info.get(chain_id)
-        }
-
-        /// Updates chain information (admin only)
-        #[ink(message)]
-        pub fn update_chain_info(
-            &mut self,
-            chain_id: ChainId,
-            info: ChainBridgeInfo,
-        ) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-
-            self.chain_info.insert(chain_id, &info);
-            Ok(())
-        }
-
-        /// Update the trusted Merkle root for a source chain (operator only).
-        /// Operators submit the root after it has been finalised on the source chain.
-        #[ink(message)]
-        pub fn update_trusted_root(
-            &mut self,
-            chain_id: ChainId,
-            root: Hash,
-        ) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if !self.bridge_operators.contains(&caller) {
-                return Err(Error::Unauthorized);
-            }
-            self.trusted_roots.insert(chain_id, &root);
-            self.env().emit_event(TrustedRootUpdated {
+        let config = BridgeConfig {
+            supported_chains: supported_chains.clone(),
+            min_signatures_required: min_signatures,
+            max_signatures_required: max_signatures,
+            default_timeout_blocks: default_timeout,
+            gas_limit_per_bridge: gas_limit,
+            emergency_pause: false,
+            metadata_preservation: true,
+        };
+
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::ReqCounter, &0u64);
+        env.storage().instance().set(&DataKey::TxCounter, &0u64);
+
+        let mut operators = Vec::new(&env);
+        operators.push_back(admin.clone());
+        env.storage().instance().set(&DataKey::Operators, &operators);
+
+        for chain_id in supported_chains.iter() {
+            let chain_info = ChainBridgeInfo {
                 chain_id,
-                root,
-                updated_by: caller,
-            });
-            Ok(())
-        }
-
-        /// Verify a cross-chain message using a Merkle proof against the stored
-        /// trusted root for `source_chain` (issue #309).
-        ///
-        /// The leaf is computed as SHA-256(message_hash || leaf_index).
-        /// Returns `true` when the proof is valid, `false` otherwise.
-        #[ink(message)]
-        pub fn verify_message_proof(
-            &self,
-            source_chain: ChainId,
-            message_hash: Hash,
-            proof: MerkleProof,
-        ) -> Result<bool, Error> {
-            let trusted_root = self
-                .trusted_roots
-                .get(source_chain)
-                .ok_or(Error::InvalidChain)?;
-
-            if trusted_root != proof.root {
-                return Ok(false);
-            }
-
-            Ok(self.verify_merkle_proof(message_hash, &proof))
-        }
-
-        /// Execute a bridge request only after its Merkle proof is verified.
-        /// Combines proof verification with execution in a single call (issue #309).
-        #[ink(message)]
-        pub fn execute_bridge_with_proof(
-            &mut self,
-            request_id: u64,
-            proof: MerkleProof,
-        ) -> Result<(), Error> {
-            let request = self
-                .bridge_requests
-                .get(request_id)
-                .ok_or(Error::InvalidRequest)?;
-
-            // Derive the message hash from the request
-            let message_hash = self.generate_transaction_hash(&request);
-
-            // Verify the Merkle proof against the trusted root for the source chain
-            let valid = self.verify_message_proof(request.source_chain, message_hash, proof)?;
-            if !valid {
-                return Err(Error::InvalidProof);
-            }
-
-            self.execute_bridge(request_id)
-        /// Updates the address of the PropertyToken contract used for ownership
-        /// verification (admin only).
-        ///
-        /// This should only be called when the canonical token contract is
-        /// migrated to a new address. Emitting an event here is intentional so
-        /// that off-chain monitors can detect unexpected changes.
-        #[ink(message)]
-        pub fn set_property_token_contract(
-            &mut self,
-            new_address: AccountId,
-        ) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
-            }
-            self.property_token_contract = new_address;
-            Ok(())
-        }
-
-        /// Returns the current PropertyToken contract address used for
-        /// ownership verification.
-        #[ink(message)]
-        pub fn get_property_token_contract(&self) -> AccountId {
-            self.property_token_contract
-        }
-
-        // Helper functions
-
-        /// Verifies that `account` is authorised to bridge `token_id`.
-        ///
-        /// Authorisation is granted when the account is either:
-        ///   1. The current owner of the token, or
-        ///   2. The account that has been explicitly approved by the owner for
-        ///      this specific token.
-        ///
-        /// The check is performed via a cross-contract call to the registered
-        /// `property_token_contract` so that ownership is always read from the
-        /// canonical on-chain source of truth.
-        fn is_authorized_for_token(&self, account: AccountId, token_id: TokenId) -> bool {
-            use ink::env::call::FromAccountId;
-            let token_contract: ink::contract_ref!(PropertyTokenOwnership) =
-                FromAccountId::from_account_id(self.property_token_contract);
-
-            // Check direct ownership first (most common path)
-            if let Some(owner) = token_contract.owner_of(token_id) {
-                if owner == account {
-                    return true;
-                }
-            } else {
-                // Token does not exist — deny
-                return false;
-            }
-
-            // Fall back to checking whether the caller holds an explicit approval
-            if let Some(approved) = token_contract.get_approved(token_id) {
-                if approved == account {
-                    return true;
-                }
-            }
-
-            false
-        }
-
-        fn get_current_chain_id(&self) -> ChainId {
-            // This should return the current chain ID
-            // For now, we'll use a default value
-            1
-        }
-
-        fn generate_transaction_hash(&self, request: &MultisigBridgeRequest) -> Hash {
-            // Generate a cryptographic SHA-256 hash of the bridge request to
-            // ensure collision resistance and prevent trivial forgery or replay.
-            use scale::Encode;
-            use ink::env::hash::{Sha2x256, HashOutput};
-
-            let data = (
-                request.request_id,
-                request.token_id,
-                request.source_chain,
-                request.destination_chain,
-                request.sender,
-                request.recipient,
-                self.env().block_timestamp(),
-            );
-
-            let encoded_data = data.encode();
-
-            // Compute SHA-256 over the encoded bytes
-            let mut output: <Sha2x256 as HashOutput>::Type = <Sha2x256 as HashOutput>::Type::default();
-            ink::env::hash_bytes::<Sha2x256>(&encoded_data, &mut output);
-
-            // Convert the hash output to the contract `Hash` type
-            Hash::from(output)
-        }
-
-        fn estimate_gas_usage(&self, request: &MultisigBridgeRequest) -> u64 {
-            let base_gas = self.config.gas_limit_per_bridge;
-            let per_byte = self
-                .chain_info
-                .get(request.destination_chain)
-                .map(|c| c.gas_multiplier as u64)
-                .unwrap_or(100);
-            let metadata_gas = request.metadata.legal_description.len() as u64 * per_byte / 100;
-            base_gas + metadata_gas
-        }
-
-        /// Verify a Merkle proof.
-        ///
-        /// Leaf = SHA-256(message_hash_bytes || leaf_index_le_bytes).
-        /// Each step: if the current index is even, node = SHA-256(current || sibling),
-        /// otherwise node = SHA-256(sibling || current). Matches standard binary Merkle trees.
-        fn verify_merkle_proof(&self, message_hash: Hash, proof: &MerkleProof) -> bool {
-            use ink::env::hash::{HashOutput, Sha2x256};
-
-            let mut current: [u8; 32] = *message_hash.as_ref();
-            // Mix in the leaf index to bind the proof to a specific position
-            let index_bytes = proof.leaf_index.to_le_bytes();
-            let mut leaf_input = [0u8; 40];
-            leaf_input[..32].copy_from_slice(&current);
-            leaf_input[32..].copy_from_slice(&index_bytes);
-            let mut leaf_hash = <Sha2x256 as HashOutput>::Type::default();
-            ink::env::hash_bytes::<Sha2x256>(&leaf_input, &mut leaf_hash);
-            current = leaf_hash;
-
-            let mut index = proof.leaf_index;
-            for sibling in &proof.proof {
-                let sibling_bytes: [u8; 32] = *sibling.as_ref();
-                let mut node_input = [0u8; 64];
-                if index % 2 == 0 {
-                    node_input[..32].copy_from_slice(&current);
-                    node_input[32..].copy_from_slice(&sibling_bytes);
-                } else {
-                    node_input[..32].copy_from_slice(&sibling_bytes);
-                    node_input[32..].copy_from_slice(&current);
-                }
-                let mut node_hash = <Sha2x256 as HashOutput>::Type::default();
-                ink::env::hash_bytes::<Sha2x256>(&node_input, &mut node_hash);
-                current = node_hash;
-                index /= 2;
-            }
-
-            Hash::from(current) == proof.root
-        }
-    }
-
-    /// Implementation of DataMigration for PropertyBridge
-    impl DataMigration for PropertyBridge {
-        type Error = Error;
-
-        #[ink(message)]
-        fn pause_for_migration(&mut self) -> Result<(), Error> {
-            self.ensure_admin()?;
-            self.config.emergency_pause = true;
-            Ok(())
-        }
-
-        #[ink(message)]
-        fn resume_after_migration(&mut self) -> Result<(), Error> {
-            self.ensure_admin()?;
-            self.config.emergency_pause = false;
-            Ok(())
-        }
-
-        #[ink(message)]
-        fn extract_data_chunk(&self, _chunk_id: u32, _start_index: u32, _count: u32) -> Result<Vec<u8>, Error> {
-            self.ensure_admin()?;
-            // In a real implementation, this would serialize a chunk of storage
-            // For now, return an empty vec as a placeholder
-            Ok(Vec::new())
-        }
-
-        #[ink(message)]
-        fn initialize_with_migrated_data(&mut self, _data: Vec<u8>) -> Result<(), Error> {
-            self.ensure_admin()?;
-            // Logic to deserialize and populate storage
-            Ok(())
-        }
-
-        #[ink(message)]
-        fn verify_migration(&self) -> Result<bool, Error> {
-            // Logic to verify checksums or record counts
-            Ok(true)
-        }
-    }
-
-    impl PropertyBridge {
-        fn ensure_admin(&self) -> Result<(), Error> {
-            if self.env().caller() != self.admin {
-                return Err(Error::Unauthorized);
-            }
-            Ok(())
-        }
-    }
-
-    // Unit tests
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use ink::env::{test, DefaultEnvironment};
-
-        fn setup_bridge() -> PropertyBridge {
-            let supported_chains = vec![1, 2, 3];
-            // Use a deterministic dummy address for the property token contract.
-            // Unit tests cannot perform cross-contract calls; the authorization
-            // path is covered by integration / e2e tests.
-            let dummy_token_contract = AccountId::from([0x01u8; 32]);
-            PropertyBridge::new(supported_chains, 2, 5, 100, 500000, dummy_token_contract)
-                .expect("valid constructor args")
-        }
-
-        #[ink::test]
-        fn test_constructor_works() {
-            let bridge = setup_bridge();
-            let config = bridge.get_config();
-            assert_eq!(config.min_signatures_required, 2);
-            assert_eq!(config.max_signatures_required, 5);
-        }
-
-        #[ink::test]
-        fn test_constructor_stores_property_token_contract() {
-            let bridge = setup_bridge();
-            assert_eq!(
-                bridge.get_property_token_contract(),
-                AccountId::from([0x01u8; 32])
-            );
-        }
-
-        /// Verifies that `initiate_bridge_multisig` returns `Unauthorized` when
-        /// the caller does not own the token.  In unit-test mode the cross-
-        /// contract call to the property-token contract will fail (no contract
-        /// deployed at the dummy address), which the runtime surfaces as a
-        /// panic / trap — the same observable outcome as a rejected call.
-        ///
-        /// Full ownership-check coverage lives in the integration tests.
-        #[ink::test]
-        #[should_panic]
-        fn test_initiate_bridge_unauthorized_panics_without_token_contract() {
-            let mut bridge = setup_bridge();
-            let accounts = test::default_accounts::<DefaultEnvironment>();
-            test::set_caller::<DefaultEnvironment>(accounts.alice);
-
-            let metadata = PropertyMetadata {
-                location: String::from("Test Property"),
-                size: 1000,
-                legal_description: String::from("Test"),
-                valuation: 100000,
-                documents_url: String::from("ipfs://test"),
+                chain_name: String::from_str(&env, "Chain"),
+                bridge_contract_address: None,
+                is_active: true,
+                gas_multiplier: 100,
+                confirmation_blocks: 6,
+                supported_tokens: Vec::new(&env),
             };
+            env.storage()
+                .persistent()
+                .set(&DataKey::ChainInfo(chain_id), &chain_info);
+        }
+    }
 
-            // This will panic because the dummy property_token_contract address
-            // has no code deployed — the cross-contract call cannot succeed.
-            let _ = bridge.initiate_bridge_multisig(1, 2, accounts.bob, 2, Some(50), metadata);
+    pub fn initiate_bridge_multisig(
+        env: Env,
+        caller: Address,
+        token_id: u64,
+        destination_chain: u32,
+        recipient: Address,
+        required_signatures: u32,
+        timeout_blocks: Option<u64>,
+        metadata: PropertyMetadata,
+    ) -> u64 {
+        caller.require_auth();
+
+        let config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        require_not_paused(&config);
+        require_supported_chain(&config, destination_chain);
+        require_valid_signatures(&config, required_signatures);
+
+        let mut counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ReqCounter)
+            .unwrap_or(0);
+        counter += 1;
+        env.storage().instance().set(&DataKey::ReqCounter, &counter);
+
+        let current_block = env.ledger().sequence() as u64;
+        let expires_at = timeout_blocks.map(|b| current_block + b);
+
+        let request = MultisigBridgeRequest {
+            request_id: counter,
+            token_id,
+            source_chain: 1,
+            destination_chain,
+            sender: caller.clone(),
+            recipient,
+            required_signatures,
+            signatures: Vec::new(&env),
+            created_at: current_block,
+            expires_at,
+            status: BridgeOperationStatus::Pending,
+            metadata,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Request(counter), &request);
+
+        env.events().publish(
+            (symbol_short!("bridge"), symbol_short!("created")),
+            (counter, token_id, caller),
+        );
+
+        counter
+    }
+
+    pub fn sign_bridge_request(env: Env, operator: Address, request_id: u64, approve: bool) {
+        operator.require_auth();
+        require_operator(&env, &operator);
+
+        let mut request: MultisigBridgeRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Request(request_id))
+            .expect("Request not found");
+
+        if let Some(expires_at) = request.expires_at {
+            if (env.ledger().sequence() as u64) > expires_at {
+                panic!("Request expired");
+            }
         }
 
-        #[ink::test]
-        fn test_sign_bridge_request_requires_operator() {
-            let mut bridge = setup_bridge();
-            let accounts = test::default_accounts::<DefaultEnvironment>();
-
-            // Charlie is not a bridge operator — signing should be rejected.
-            test::set_caller::<DefaultEnvironment>(accounts.charlie);
-            let result = bridge.sign_bridge_request(999, true);
-            assert_eq!(result, Err(Error::Unauthorized));
+        if request.signatures.contains(operator.clone()) {
+            panic!("Already signed");
         }
 
-        #[ink::test]
-        fn test_set_property_token_contract_admin_only() {
-            let mut bridge = setup_bridge();
-            let accounts = test::default_accounts::<DefaultEnvironment>();
+        request.signatures.push_back(operator);
 
-            // Non-admin should be rejected.
-            test::set_caller::<DefaultEnvironment>(accounts.bob);
-            let result = bridge.set_property_token_contract(AccountId::from([0x02u8; 32]));
-            assert_eq!(result, Err(Error::Unauthorized));
-
-            // Admin (alice, the deployer) should succeed.
-            test::set_caller::<DefaultEnvironment>(accounts.alice);
-            let result = bridge.set_property_token_contract(AccountId::from([0x02u8; 32]));
-            assert!(result.is_ok());
-            assert_eq!(
-                bridge.get_property_token_contract(),
-                AccountId::from([0x02u8; 32])
-            );
+        if !approve {
+            request.status = BridgeOperationStatus::Failed;
+        } else if request.signatures.len() >= request.required_signatures {
+            request.status = BridgeOperationStatus::Locked;
         }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Request(request_id), &request);
+    }
+
+    pub fn execute_bridge(env: Env, operator: Address, request_id: u64) {
+        operator.require_auth();
+        require_operator(&env, &operator);
+
+        let mut request: MultisigBridgeRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Request(request_id))
+            .expect("Request not found");
+
+        if request.status != BridgeOperationStatus::Locked {
+            panic!("Request not ready");
+        }
+
+        let tx_hash = env
+            .crypto()
+            .sha256(&Bytes::from_slice(&env, &request_id.to_be_bytes()));
+
+        let mut tx_counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TxCounter)
+            .unwrap_or(0);
+        tx_counter += 1;
+        env.storage().instance().set(&DataKey::TxCounter, &tx_counter);
+
+        let transaction = BridgeTransaction {
+            transaction_id: tx_counter,
+            token_id: request.token_id,
+            source_chain: request.source_chain,
+            destination_chain: request.destination_chain,
+            sender: request.sender.clone(),
+            recipient: request.recipient.clone(),
+            transaction_hash: tx_hash.clone(),
+            timestamp: env.ledger().timestamp(),
+            gas_used: 0,
+            status: BridgeOperationStatus::InTransit,
+            metadata: request.metadata.clone(),
+        };
+
+        request.status = BridgeOperationStatus::Completed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Request(request_id), &request);
+        env.storage()
+            .persistent()
+            .set(&DataKey::VerifiedTx(tx_hash.clone()), &true);
+
+        let mut history: Vec<BridgeTransaction> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::History(request.sender.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        if history.len() >= MAX_HISTORY_ITEMS {
+            history.remove(0);
+        }
+        history.push_back(transaction);
+        env.storage()
+            .persistent()
+            .set(&DataKey::History(request.sender.clone()), &history);
+
+        env.events().publish(
+            (symbol_short!("bridge"), symbol_short!("executed")),
+            (request_id, tx_hash),
+        );
+    }
+
+    pub fn recover_failed_bridge(
+        env: Env,
+        admin: Address,
+        request_id: u64,
+        recovery_action: RecoveryAction,
+    ) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+
+        let mut request: MultisigBridgeRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Request(request_id))
+            .expect("Request not found");
+
+        if !matches!(
+            request.status,
+            BridgeOperationStatus::Failed | BridgeOperationStatus::Expired
+        ) {
+            panic!("Request not in failed state");
+        }
+
+        match recovery_action {
+            RecoveryAction::RetryBridge => {
+                request.status = BridgeOperationStatus::Pending;
+                request.signatures = Vec::new(&env);
+            }
+            RecoveryAction::CancelBridge
+            | RecoveryAction::UnlockToken
+            | RecoveryAction::RefundGas => {
+                request.status = BridgeOperationStatus::Failed;
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Request(request_id), &request);
+    }
+
+    pub fn set_pause(env: Env, admin: Address, paused: bool) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+
+        let mut config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        config.emergency_pause = paused;
+        env.storage().instance().set(&DataKey::Config, &config);
+    }
+
+    pub fn get_history(env: Env, account: Address) -> Vec<BridgeTransaction> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::History(account))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn add_operator(env: Env, admin: Address, operator: Address) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+
+        let mut operators: Vec<Address> =
+            env.storage().instance().get(&DataKey::Operators).unwrap();
+        if !operators.contains(operator.clone()) {
+            operators.push_back(operator);
+            env.storage().instance().set(&DataKey::Operators, &operators);
+        }
+    }
+
+    pub fn remove_operator(env: Env, admin: Address, operator: Address) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+
+        let operators: Vec<Address> =
+            env.storage().instance().get(&DataKey::Operators).unwrap();
+        let mut new_operators = Vec::new(&env);
+        for op in operators.iter() {
+            if op != operator {
+                new_operators.push_back(op);
+            }
+        }
+        env.storage().instance().set(&DataKey::Operators, &new_operators);
     }
 }

--- a/stellar-insured-contracts/contracts/bridge/src/storage.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/storage.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::{contracttype, Address, BytesN};
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Admin,
+    Request(u64),
+    History(Address),
+    ChainInfo(u32),
+    VerifiedTx(BytesN<32>),
+    Operators,
+    ReqCounter,
+    TxCounter,
+}
+
+/// Maximum bridge history entries retained per account (prevents unbounded growth).
+pub const MAX_HISTORY_ITEMS: u32 = 50;

--- a/stellar-insured-contracts/contracts/bridge/src/types.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/types.rs
@@ -1,0 +1,88 @@
+use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[contracttype]
+pub enum BridgeOperationStatus {
+    Pending,
+    Locked,
+    Completed,
+    Failed,
+    Expired,
+    InTransit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct PropertyMetadata {
+    pub location: String,
+    pub size: u64,
+    pub legal_description: String,
+    pub valuation: u128,
+    pub documents_url: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct BridgeConfig {
+    pub supported_chains: Vec<u32>,
+    pub min_signatures_required: u32,
+    pub max_signatures_required: u32,
+    pub default_timeout_blocks: u64,
+    pub gas_limit_per_bridge: u64,
+    pub emergency_pause: bool,
+    pub metadata_preservation: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct MultisigBridgeRequest {
+    pub request_id: u64,
+    pub token_id: u64,
+    pub source_chain: u32,
+    pub destination_chain: u32,
+    pub sender: Address,
+    pub recipient: Address,
+    pub required_signatures: u32,
+    pub signatures: Vec<Address>,
+    pub created_at: u64,
+    pub expires_at: Option<u64>,
+    pub status: BridgeOperationStatus,
+    pub metadata: PropertyMetadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct BridgeTransaction {
+    pub transaction_id: u64,
+    pub token_id: u64,
+    pub source_chain: u32,
+    pub destination_chain: u32,
+    pub sender: Address,
+    pub recipient: Address,
+    pub transaction_hash: BytesN<32>,
+    pub timestamp: u64,
+    pub gas_used: u64,
+    pub status: BridgeOperationStatus,
+    pub metadata: PropertyMetadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct ChainBridgeInfo {
+    pub chain_id: u32,
+    pub chain_name: String,
+    pub bridge_contract_address: Option<String>,
+    pub is_active: bool,
+    pub gas_multiplier: u32,
+    pub confirmation_blocks: u32,
+    pub supported_tokens: Vec<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[contracttype]
+pub enum RecoveryAction {
+    UnlockToken,
+    RefundGas,
+    RetryBridge,
+    CancelBridge,
+}

--- a/stellar-insured-contracts/contracts/bridge/src/validation.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/validation.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::storage::DataKey;
+use crate::types::BridgeConfig;
+
+/// Panics if the bridge is paused.
+pub fn require_not_paused(config: &BridgeConfig) {
+    if config.emergency_pause {
+        panic!("Bridge paused");
+    }
+}
+
+/// Panics if `destination_chain` is not in the supported chains list.
+pub fn require_supported_chain(config: &BridgeConfig, destination_chain: u32) {
+    if !config.supported_chains.contains(destination_chain) {
+        panic!("Unsupported chain");
+    }
+}
+
+/// Panics if `required_signatures` is outside the configured [min, max] range.
+pub fn require_valid_signatures(config: &BridgeConfig, required_signatures: u32) {
+    if required_signatures < config.min_signatures_required
+        || required_signatures > config.max_signatures_required
+    {
+        panic!("Invalid signature requirement");
+    }
+}
+
+/// Panics if `caller` is not in the operators list.
+pub fn require_operator(env: &Env, caller: &Address) {
+    let operators: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::Operators)
+        .unwrap();
+    if !operators.contains(caller.clone()) {
+        panic!("Not an operator");
+    }
+}
+
+/// Panics if `caller` is not the stored admin.
+pub fn require_admin(env: &Env, caller: &Address) {
+    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    if *caller != admin {
+        panic!("Unauthorized");
+    }
+}

--- a/stellar-insured-contracts/contracts/escrow/src/lib.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/lib.rs
@@ -1,215 +1,203 @@
 #![no_std]
-//! Escrow contract for property transactions on Soroban.
-//!
-//! The contract manages escrow lifecycle states (`created`, `funded`, `released`) and
-//! stores escrow records in a single instance storage map keyed by escrow id.
-//! Storage reads are intentionally cached in local variables per operation to avoid
-//! redundant instance lookups in storage-heavy paths.
 
-use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, Symbol, Map, Vec, Val, symbol_short};
+mod storage;
+mod types;
+mod validation;
 
-#[contracterror]
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(u32)]
-pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    Unauthorized = 3,
-    InvalidAmount = 4,
-    BuyerSellerSame = 5,
-    EscrowNotFound = 6,
-    InvalidState = 7,
-    EscrowNotCreated = 8,
-    EscrowNotFunded = 9,
-}
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
+
+use storage::DataKey;
+use types::{ApprovalType, EscrowData, EscrowStatus, MultiSigConfig};
+use validation::{require_not_paused, require_valid_multisig};
 
 #[contract]
-pub struct EscrowContract;
+pub struct AdvancedEscrow;
 
 #[contractimpl]
-impl EscrowContract {
-    fn load_escrows(env: &Env) -> Result<Map<u64, Val>, Error> {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("escrow"))
-            .ok_or(Error::NotInitialized)
-    }
-
-    fn save_escrows(env: &Env, escrows: &Map<u64, Val>) {
-        env.storage()
-            .instance()
-            .set(&symbol_short!("escrow"), escrows);
-    }
-
-    /// Initialize the escrow contract
-    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            return Err(Error::AlreadyInitialized);
+impl AdvancedEscrow {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
         }
-        env.storage().instance().set(&symbol_short!("admin"), &admin);
-        env.storage().instance().set(&symbol_short!("escrow_count"), &0u64);
-        Ok(())
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::EscrowCount, &0u64);
+        env.storage().instance().set(&DataKey::Paused, &false);
     }
 
-    /// Transfer admin to a new address (admin only)
-    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .ok_or(Error::NotInitialized)?;
+    pub fn set_pause(env: Env, admin: Address, paused: bool) {
         admin.require_auth();
-        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
-        Ok(())
+        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != current_admin {
+            panic!("Unauthorized");
+        }
+        env.storage().instance().set(&DataKey::Paused, &paused);
     }
 
-    /// Create a new escrow
-    #[must_use]
-    pub fn create_escrow(
+    pub fn create_escrow_advanced(
         env: Env,
         property_id: u64,
+        amount: i128,
         buyer: Address,
         seller: Address,
-        amount: u128,
-    ) -> Result<u64, Error> {
-        if amount == 0 {
-            return Err(Error::InvalidAmount);
-        }
-        if buyer == seller {
-            return Err(Error::BuyerSellerSame);
-        }
+        participants: Vec<Address>,
+        required_signatures: u32,
+        release_time_lock: Option<u64>,
+    ) -> u64 {
+        require_not_paused(&env);
+        require_valid_multisig(required_signatures, participants.len());
 
-        let admin: Address = env
+        let mut count: u64 = env
             .storage()
             .instance()
-            .get(&symbol_short!("admin"))
-            .ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-
-        let mut escrow_count: u64 = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("escrow_count"))
+            .get(&DataKey::EscrowCount)
             .unwrap_or(0);
-        escrow_count += 1;
-        env.storage()
-            .instance()
-            .set(&symbol_short!("escrow_count"), &escrow_count);
+        count += 1;
+        env.storage().instance().set(&DataKey::EscrowCount, &count);
 
-        let escrow_key = symbol_short!("escrow");
-        let mut escrows: Map<u64, Val> = env
-            .storage()
-            .instance()
-            .get(&escrow_key)
-            .unwrap_or(Map::new(&env));
-
-        let escrow_data = (
+        let escrow_data = EscrowData {
+            id: count,
             property_id,
-            buyer.clone(),
-            seller.clone(),
+            buyer,
+            seller,
             amount,
-            0u128,                    // deposited_amount
-            symbol_short!("created"), // status
-            env.ledger().timestamp(), // created_at
+            deposited_amount: 0,
+            status: EscrowStatus::Created,
+            created_at: env.ledger().timestamp(),
+            release_time_lock,
+            participants: participants.clone(),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(count), &escrow_data);
+
+        let config = MultiSigConfig {
+            required_signatures,
+            signers: participants,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MultiSig(count), &config);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("created")),
+            (count, property_id, amount),
         );
 
-        escrows.set(escrow_count, escrow_data.into());
-        env.storage().instance().set(&escrow_key, &escrows);
-
-        Ok(escrow_count)
+        count
     }
 
-    /// Deposit funds into escrow
-    pub fn deposit_funds(env: Env, escrow_id: u64, amount: u128) -> Result<(), Error> {
-        if amount == 0 {
-            return Err(Error::InvalidAmount);
+    pub fn deposit_funds(env: Env, escrow_id: u64, amount: i128) {
+        require_not_paused(&env);
+
+        let mut escrow: EscrowData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
+
+        if escrow.status != EscrowStatus::Created && escrow.status != EscrowStatus::Funded {
+            panic!("Invalid status");
         }
 
-        // Read escrow map once, operate in memory, write back once.
-        let mut escrows: Map<u64, Val> = Self::load_escrows(&env)?;
-        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows
-            .get(escrow_id)
-            .ok_or(Error::EscrowNotFound)?
-            .into();
-
-        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) =
-            escrow_data;
-
-        if status != symbol_short!("created") {
-            return Err(Error::EscrowNotCreated);
-        }
-
-        buyer.require_auth();
-
-        let new_deposited = deposited_amount + amount;
-        let new_status = if new_deposited >= total_amount {
-            symbol_short!("funded")
+        escrow.deposited_amount += amount;
+        escrow.status = if escrow.deposited_amount >= escrow.amount {
+            EscrowStatus::Active
         } else {
-            symbol_short!("created")
+            EscrowStatus::Funded
         };
 
-        let updated_escrow = (
-            property_id,
-            buyer,
-            seller,
-            total_amount,
-            new_deposited,
-            new_status,
-            created_at,
+        env.storage()
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("funded")),
+            (escrow_id, amount),
         );
-        escrows.set(escrow_id, updated_escrow.into());
-        Self::save_escrows(&env, &escrows);
-        Ok(())
     }
 
-    /// Release escrow funds
-    pub fn release_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
-        // Read escrow map once, operate in memory, write back once.
-        let mut escrows: Map<u64, Val> = Self::load_escrows(&env)?;
-        let escrow_data: (u64, Address, Address, u128, u128, Symbol, u64) = escrows
-            .get(escrow_id)
-            .ok_or(Error::EscrowNotFound)?
-            .into();
+    pub fn release_funds(env: Env, escrow_id: u64) {
+        require_not_paused(&env);
 
-        let (property_id, buyer, seller, total_amount, deposited_amount, status, created_at) =
-            escrow_data;
+        let mut escrow: EscrowData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .expect("Escrow not found");
 
-        if status != symbol_short!("funded") {
-            return Err(Error::EscrowNotFunded);
+        if escrow.status != EscrowStatus::Active {
+            panic!("Invalid status");
         }
 
-        seller.require_auth();
+        if let Some(time_lock) = escrow.release_time_lock {
+            if env.ledger().timestamp() < time_lock {
+                panic!("Time lock active");
+            }
+        }
 
-        let updated_escrow = (
-            property_id,
-            buyer,
-            seller,
-            total_amount,
-            deposited_amount,
-            symbol_short!("released"),
-            created_at,
-        );
-        escrows.set(escrow_id, updated_escrow.into());
-        Self::save_escrows(&env, &escrows);
-        Ok(())
-    }
+        let sig_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SigCount(escrow_id, ApprovalType::Release))
+            .unwrap_or(0);
+        let config: MultiSigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultiSig(escrow_id))
+            .unwrap();
 
-    /// Get escrow details
-    #[must_use]
-    pub fn get_escrow(
-        env: Env,
-        escrow_id: u64,
-    ) -> Result<(u64, Address, Address, u128, u128, Symbol, u64), Error> {
-        let escrows: Map<u64, Val> = Self::load_escrows(&env)?;
-        Ok(escrows.get(escrow_id).ok_or(Error::EscrowNotFound)?.into())
-    }
+        if sig_count < config.required_signatures {
+            panic!("Signature threshold not met");
+        }
 
-    /// Get total escrow count
-    #[must_use]
-    pub fn escrow_count(env: Env) -> u64 {
+        let amount = escrow.deposited_amount;
+        escrow.status = EscrowStatus::Released;
+        escrow.deposited_amount = 0;
         env.storage()
-            .instance()
-            .get(&symbol_short!("escrow_count"))
-            .unwrap_or(0)
+            .persistent()
+            .set(&DataKey::Escrow(escrow_id), &escrow);
+
+        env.events().publish(
+            (symbol_short!("escrow"), symbol_short!("released")),
+            (escrow_id, amount),
+        );
+    }
+
+    pub fn sign_approval(env: Env, escrow_id: u64, approval_type: ApprovalType, signer: Address) {
+        require_not_paused(&env);
+        signer.require_auth();
+
+        let config: MultiSigConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultiSig(escrow_id))
+            .expect("Escrow not found");
+
+        if !config.signers.contains(signer.clone()) {
+            panic!("Unauthorized");
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Signature(escrow_id, approval_type, signer.clone()))
+        {
+            panic!("Already signed");
+        }
+
+        env.storage().persistent().set(
+            &DataKey::Signature(escrow_id, approval_type, signer),
+            &true,
+        );
+
+        let mut count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SigCount(escrow_id, approval_type))
+            .unwrap_or(0);
+        count += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::SigCount(escrow_id, approval_type), &count);
     }
 }

--- a/stellar-insured-contracts/contracts/escrow/src/storage.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/storage.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contracttype, Address};
+
+use crate::types::ApprovalType;
+
+#[contracttype]
+pub enum DataKey {
+    Escrow(u64),
+    EscrowCount,
+    Admin,
+    Paused,
+    MultiSig(u64),
+    Signature(u64, ApprovalType, Address),
+    SigCount(u64, ApprovalType),
+}

--- a/stellar-insured-contracts/contracts/escrow/src/types.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/types.rs
@@ -1,0 +1,43 @@
+use soroban_sdk::{contracttype, Address, Vec};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[contracttype]
+pub enum EscrowStatus {
+    Created,
+    Funded,
+    Active,
+    Released,
+    Refunded,
+    Disputed,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[contracttype]
+pub enum ApprovalType {
+    Release,
+    Refund,
+    EmergencyOverride,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct EscrowData {
+    pub id: u64,
+    pub property_id: u64,
+    pub buyer: Address,
+    pub seller: Address,
+    pub amount: i128,
+    pub deposited_amount: i128,
+    pub status: EscrowStatus,
+    pub created_at: u64,
+    pub release_time_lock: Option<u64>,
+    pub participants: Vec<Address>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct MultiSigConfig {
+    pub required_signatures: u32,
+    pub signers: Vec<Address>,
+}

--- a/stellar-insured-contracts/contracts/escrow/src/validation.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/validation.rs
@@ -1,0 +1,26 @@
+use soroban_sdk::Env;
+
+use crate::storage::DataKey;
+
+/// Panics if the contract is paused.
+pub fn require_not_paused(env: &Env) {
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false);
+    if paused {
+        panic!("Contract is paused");
+    }
+}
+
+/// Panics if `required_signatures` is zero, `participants` is empty,
+/// or `required_signatures` exceeds the number of participants.
+pub fn require_valid_multisig(required_signatures: u32, participant_count: u32) {
+    if required_signatures == 0
+        || participant_count == 0
+        || required_signatures > participant_count
+    {
+        panic!("Invalid configuration");
+    }
+}

--- a/stellar-insured-contracts/contracts/insurance/src/events.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/events.rs
@@ -1,0 +1,284 @@
+// This file is included inside the `propchain_insurance` ink::contract module.
+// All types referenced here are in scope via the parent module's `use` statements.
+
+#[ink(event)]
+pub struct PolicyCreated {
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub policyholder: AccountId,
+    #[ink(topic)]
+    pub property_id: u64,
+    pub coverage_type: CoverageType,
+    pub coverage_amount: u128,
+    pub premium_amount: u128,
+    pub start_time: u64,
+    pub end_time: u64,
+}
+
+#[ink(event)]
+pub struct PolicyIssued {
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub holder: AccountId,
+    pub coverage_amount: u128,
+    pub premium_amount: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct PolicyCancelled {
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub policyholder: AccountId,
+    pub cancelled_at: u64,
+    pub reason: Option<String>,
+}
+
+#[ink(event)]
+pub struct PolicyRenewed {
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub holder: AccountId,
+    pub renewal_premium: u128,
+    pub new_end_time: u64,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct PolicyExpired {
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub holder: AccountId,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct ClaimSubmitted {
+    #[ink(topic)]
+    pub claim_id: u64,
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub claimant: AccountId,
+    pub claim_amount: u128,
+    pub submitted_at: u64,
+}
+
+#[ink(event)]
+pub struct ClaimApproved {
+    #[ink(topic)]
+    pub claim_id: u64,
+    #[ink(topic)]
+    pub policy_id: u64,
+    pub payout_amount: u128,
+    pub approved_by: AccountId,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct ClaimRejected {
+    #[ink(topic)]
+    pub claim_id: u64,
+    #[ink(topic)]
+    pub policy_id: u64,
+    pub reason: String,
+    pub rejected_by: AccountId,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct PayoutExecuted {
+    #[ink(topic)]
+    pub claim_id: u64,
+    #[ink(topic)]
+    pub recipient: AccountId,
+    pub amount: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct PoolCapitalized {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct LiquidityDeposited {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub accumulated_reward_per_share: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct LiquidityWithdrawn {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub principal: u128,
+    pub rewards_paid: u128,
+    pub accumulated_reward_per_share: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct RewardsClaimed {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub accumulated_reward_per_share: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct RewardsReinvested {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub new_stake: u128,
+    pub accumulated_reward_per_share: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct RewardsVestingStarted {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub vesting_start: u64,
+    pub vesting_cliff: u64,
+    pub vesting_duration: u64,
+}
+
+#[ink(event)]
+pub struct VestedRewardsClaimed {
+    #[ink(topic)]
+    pub pool_id: u64,
+    #[ink(topic)]
+    pub provider: AccountId,
+    pub amount: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct ReinsuranceActivated {
+    #[ink(topic)]
+    pub claim_id: u64,
+    pub agreement_id: u64,
+    pub recovery_amount: u128,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct InsuranceTokenMinted {
+    #[ink(topic)]
+    pub token_id: u64,
+    #[ink(topic)]
+    pub policy_id: u64,
+    #[ink(topic)]
+    pub owner: AccountId,
+    pub face_value: u128,
+}
+
+#[ink(event)]
+pub struct InsuranceTokenTransferred {
+    #[ink(topic)]
+    pub token_id: u64,
+    #[ink(topic)]
+    pub from: AccountId,
+    #[ink(topic)]
+    pub to: AccountId,
+    pub price: u128,
+}
+
+#[ink(event)]
+pub struct RiskAssessmentUpdated {
+    #[ink(topic)]
+    pub property_id: u64,
+    pub overall_score: u32,
+    pub risk_level: RiskLevel,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct EvidenceSubmitted {
+    #[ink(topic)]
+    pub evidence_id: u64,
+    #[ink(topic)]
+    pub raised_by: AccountId,
+    pub dispute_deadline: u64,
+    pub previous_status: ClaimStatus,
+    pub timestamp: u64,
+    pub claim_id: u64,
+    pub evidence_type: String,
+    pub ipfs_hash: String,
+    pub submitter: AccountId,
+    pub submitted_at: u64,
+}
+
+#[ink(event)]
+pub struct EvidenceVerified {
+    #[ink(topic)]
+    pub evidence_id: u64,
+    pub verified_by: AccountId,
+    pub is_valid: bool,
+    pub verified_at: u64,
+}
+
+#[ink(event)]
+pub struct ContractPaused {
+    #[ink(topic)]
+    pub paused_by: AccountId,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct ContractUnpaused {
+    #[ink(topic)]
+    pub unpaused_by: AccountId,
+    pub timestamp: u64,
+}
+
+#[ink(event)]
+pub struct PauseProposed {
+    #[ink(topic)]
+    pub proposed_by: AccountId,
+    pub earliest_execution: u64,
+}
+
+#[ink(event)]
+pub struct AdminProposed {
+    #[ink(topic)]
+    pub proposed_by: AccountId,
+    #[ink(topic)]
+    pub new_admin: AccountId,
+    pub earliest_execution: u64,
+}
+
+#[ink(event)]
+pub struct AdminChanged {
+    #[ink(topic)]
+    pub old_admin: AccountId,
+    #[ink(topic)]
+    pub new_admin: AccountId,
+    pub timestamp: u64,
+}

--- a/stellar-insured-contracts/contracts/insurance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/lib.rs
@@ -1,15 +1,24 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 #![allow(
-
-//! Property insurance contract module wiring, types, and delegated implementations.
-
     clippy::arithmetic_side_effects,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::needless_borrows_for_generic_args
 )]
 
+//! Property insurance contract module wiring, types, and delegated implementations.
+
 use ink::storage::Mapping;
+
+pub mod types;
+
+// Existing helper modules (unchanged)
+pub mod constants;
+pub mod errors;
+pub mod result_types;
+pub mod storage_helpers;
+pub mod storage_keys;
+pub mod storage_ttl;
 
 /// Decentralized Property Insurance Platform
 #[ink::contract]
@@ -17,421 +26,18 @@ mod propchain_insurance {
     use super::*;
     use ink::prelude::{string::String, vec::Vec};
 
-    // =========================================================================
-    // ERROR TYPES
-    // =========================================================================
-
-    #[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum InsuranceError {
-        Unauthorized,
-        PolicyNotFound,
-        ClaimNotFound,
-        PoolNotFound,
-        PolicyAlreadyActive,
-        PolicyExpired,
-        PolicyInactive,
-        InsufficientPremium,
-        InsufficientPoolFunds,
-        ClaimAlreadyProcessed,
-        ClaimExceedsCoverage,
-        InvalidParameters,
-        OracleVerificationFailed,
-        ReinsuranceCapacityExceeded,
-        TokenNotFound,
-        TransferFailed,
-        CooldownPeriodActive,
-        PropertyNotInsurable,
-        DuplicateClaim,
-        // #133 – evidence validation errors
-        InvalidEvidenceUri,
-        InvalidEvidenceHash,
-        InvalidEvidenceNonce,
-        // #134 – dispute errors
-        DisputeWindowExpired,
-        InvalidDisputeTransition,
-        // Security errors
-        ContractPaused,
-        NonceAlreadyUsed,
-        PremiumTooLow,
-        // Evidence validation errors
-        EvidenceNonceEmpty,
-        EvidenceInvalidUriScheme,
-        EvidenceInvalidHashLength,
-        ZeroAmount,
-        InsufficientStake,
-        InsufficientPoolLiquidity,
-        // Time-lock errors (#301)
-        TimeLockPending,
-        TimeLockNotReady,
-    }
-
-    /// Fixed-point precision for [`RiskPool::accumulated_reward_per_share`] (1e18).
-    const REWARD_PRECISION: u128 = 1_000_000_000_000_000_000;
+    pub use crate::types::{
+        ActuarialModel, BatchClaimResult, BatchClaimSummary, ClaimStatus, CoverageType,
+        EvidenceItem, EvidenceMetadata, EvidenceVerification, InsuranceClaim, InsuranceError,
+        InsurancePolicy, InsuranceToken, PolicyStatus, PolicyType, PoolLiquidityProvider,
+        PremiumCalculation, ReinsuranceAgreement, RiskAssessment, RiskLevel, RiskPool,
+        UnderwritingCriteria, REWARD_PRECISION,
+    };
 
     // =========================================================================
-    // DATA TYPES
+    // EVENTS  (extracted to events.rs, included here so ink! macros see them)
     // =========================================================================
-
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        scale::Encode,
-        scale::Decode,
-        ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum PolicyStatus {
-        Active,
-        Renewed,
-        Expired,
-        Cancelled,
-        Claimed,
-        Suspended,
-    }
-
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        scale::Encode,
-        scale::Decode,
-        ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum PolicyType {
-        Standard,
-        Parametric,
-    }
-
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        scale::Encode,
-        scale::Decode,
-        ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum CoverageType {
-        Fire,
-        Flood,
-        Earthquake,
-        Theft,
-        LiabilityDamage,
-        NaturalDisaster,
-        Comprehensive,
-    }
-
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        scale::Encode,
-        scale::Decode,
-        ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum ClaimStatus {
-        Pending,
-        UnderReview,
-        OracleVerifying,
-        Approved,
-        Rejected,
-        Paid,
-        Disputed,
-    }
-
-    #[derive(
-        Debug,
-        Clone,
-        PartialEq,
-        Eq,
-        scale::Encode,
-        scale::Decode,
-        ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub enum RiskLevel {
-        VeryLow,
-        Low,
-        Medium,
-        High,
-        VeryHigh,
-    }
-
-    /// Structured evidence attached to a claim submission.
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct EvidenceMetadata {
-        /// Non-empty nonce / type identifier (e.g. "photo", "report", "sensor")
-        pub evidence_type: String,
-        /// URI pointing to the evidence artifact (must start with "ipfs://" or "https://")
-        pub reference_uri: String,
-        /// SHA-256 content hash – exactly 32 bytes
-        pub content_hash: Vec<u8>,
-        /// Optional human-readable description
-        pub description: Option<String>,
-    }
-
-    impl From<&str> for EvidenceMetadata {
-        fn from(s: &str) -> Self {
-            EvidenceMetadata {
-                evidence_type: "unknown".into(),
-                reference_uri: s.into(),
-                content_hash: vec![0u8; 32],
-                description: None,
-            }
-        }
-    }
-
-        #[derive(
-            Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-        )]
-        #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-        pub struct EvidenceItem {
-            pub id: u64,
-            pub claim_id: u64,
-            pub evidence_type: String,
-            pub ipfs_hash: String,
-            pub ipfs_uri: String,
-            pub content_hash: Vec<u8>,
-            pub file_size: u64,
-            pub submitter: AccountId,
-            pub submitted_at: u64,
-            pub verified: bool,
-            pub verified_by: Option<AccountId>,
-            pub verified_at: Option<u64>,
-            pub verification_notes: Option<String>,
-            pub metadata_url: Option<String>,
-        }
-
-        #[derive(
-            Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-        )]
-        #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-        pub struct EvidenceVerification {
-            pub evidence_id: u64,
-            pub verifier: AccountId,
-            pub verified_at: u64,
-            pub is_valid: bool,
-            pub notes: String,
-            pub ipfs_accessible: bool,
-            pub hash_matches: bool,
-        }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct InsurancePolicy {
-        pub policy_id: u64,
-        pub property_id: u64,
-        pub policyholder: AccountId,
-        pub coverage_type: CoverageType,
-        pub coverage_amount: u128, // Max payout in USD (8 decimals)
-        pub premium_amount: u128,  // Annual premium in native token
-        pub deductible: u128,      // Deductible amount
-        pub start_time: u64,
-        pub end_time: u64,
-        pub status: PolicyStatus,
-        pub risk_level: RiskLevel,
-        pub pool_id: u64,
-        pub claims_count: u32,
-        pub total_claimed: u128,
-        pub metadata_url: String,
-        pub policy_type: PolicyType,
-        pub event_id: Option<u64>,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct InsuranceClaim {
-        pub claim_id: u64,
-        pub policy_id: u64,
-        pub claimant: AccountId,
-        pub claim_amount: u128,
-        pub description: String,
-        pub evidence: EvidenceMetadata,
-        pub evidence_ids: Vec<u64>,
-        pub oracle_report_url: String,
-        pub status: ClaimStatus,
-        pub submitted_at: u64,
-        pub processed_at: Option<u64>,
-        pub payout_amount: u128,
-        pub assessor: Option<AccountId>,
-        pub rejection_reason: String,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct RiskPool {
-        pub pool_id: u64,
-        pub name: String,
-        pub coverage_type: CoverageType,
-        pub total_capital: u128,
-        pub available_capital: u128,
-        pub total_premiums_collected: u128,
-        pub total_claims_paid: u128,
-        pub active_policies: u64,
-        pub max_coverage_ratio: u32, // Max exposure as % of pool (basis points, e.g. 8000 = 80%)
-        pub reinsurance_threshold: u128, // Claim size above which reinsurance kicks in
-        pub created_at: u64,
-        pub is_active: bool,
-        /// Sum of LP stakes; denominator for reward-per-share accrual.
-        pub total_provider_stake: u128,
-        /// Scaled accumulated rewards per staked unit ([`REWARD_PRECISION`] fixed-point).
-        pub accumulated_reward_per_share: u128,
-        /// Vesting cliff in seconds (0 = no cliff)
-        pub vesting_cliff_seconds: u64,
-        /// Vesting duration in seconds (0 = no vesting; if >0 enables vesting)
-        pub vesting_duration_seconds: u64,
-        /// Early withdrawal penalty applied to unvested rewards (basis points, e.g. 500 = 5%)
-        pub early_withdrawal_penalty_bps: u32,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct RiskAssessment {
-        pub property_id: u64,
-        pub location_risk_score: u32,     // 0-100
-        pub construction_risk_score: u32, // 0-100
-        pub age_risk_score: u32,          // 0-100
-        pub claims_history_score: u32,    // 0-100 (lower = more claims)
-        pub overall_risk_score: u32,      // 0-100
-        pub risk_level: RiskLevel,
-        pub assessed_at: u64,
-        pub valid_until: u64,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct PremiumCalculation {
-        pub base_rate: u32,           // Basis points (e.g. 150 = 1.50%)
-        pub risk_multiplier: u32,     // Applied based on risk score (100 = 1.0x)
-        pub coverage_multiplier: u32, // Applied based on coverage type
-        pub annual_premium: u128,     // Final annual premium
-        pub monthly_premium: u128,    // Monthly equivalent
-        pub deductible: u128,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct ReinsuranceAgreement {
-        pub agreement_id: u64,
-        pub reinsurer: AccountId,
-        pub coverage_limit: u128,
-        pub retention_limit: u128, // Our retention before reinsurance activates
-        pub premium_ceded_rate: u32, // % of premiums ceded to reinsurer (basis points)
-        pub coverage_types: Vec<CoverageType>,
-        pub start_time: u64,
-        pub end_time: u64,
-        pub is_active: bool,
-        pub total_ceded_premiums: u128,
-        pub total_recoveries: u128,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct InsuranceToken {
-        pub token_id: u64,
-        pub policy_id: u64,
-        pub owner: AccountId,
-        pub face_value: u128,
-        pub is_tradeable: bool,
-        pub created_at: u64,
-        pub listed_price: Option<u128>,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct ActuarialModel {
-        pub model_id: u64,
-        pub coverage_type: CoverageType,
-        pub loss_frequency: u32, // Expected losses per 1000 policies (basis points)
-        pub average_loss_severity: u128, // Average loss size
-        pub expected_loss_ratio: u32, // Expected loss ratio (basis points)
-        pub confidence_level: u32, // 0-100
-        pub last_updated: u64,
-        pub data_points: u32,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct UnderwritingCriteria {
-        pub max_property_age_years: u32,
-        pub min_property_value: u128,
-        pub max_property_value: u128,
-        pub excluded_locations: Vec<String>,
-        pub required_safety_features: bool,
-        pub max_previous_claims: u32,
-        pub min_risk_score: u32,
-    }
-
-    /// Result of a single batch claim operation
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct BatchClaimResult {
-        pub claim_id: u64,
-        pub success: bool,
-        pub error: Option<InsuranceError>,
-    }
-
-    /// Summary of batch claim processing
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct BatchClaimSummary {
-        pub total_processed: u64,
-        pub successful: u64,
-        pub failed: u64,
-        pub results: Vec<BatchClaimResult>,
-    }
-
-    #[derive(
-        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
-    )]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct PoolLiquidityProvider {
-        pub provider: AccountId,
-        pub pool_id: u64,
-        pub provider_stake: u128,
-        /// Reward debt in fixed-point units: keeps pending = stake * acc_rps / P - reward_debt.
-        pub reward_debt: u128,
-        pub deposited_at: u64,
-        /// Total rewards moved into vesting schedule (not yet fully claimed)
-        pub vesting_total: u128,
-        /// Amount of vested rewards already claimed by provider
-        pub vesting_claimed: u128,
-        /// Vesting schedule start timestamp (seconds)
-        pub vesting_start: u64,
-    }
+    include!("events.rs");
 
     // =========================================================================
     // STORAGE
@@ -466,14 +72,14 @@ mod propchain_insurance {
         // Insurance Tokens (secondary market)
         insurance_tokens: Mapping<u64, InsuranceToken>,
         token_count: u64,
-        token_listings: Vec<u64>, // Tokens listed for sale
+        token_listings: Vec<u64>,
 
         // Actuarial Models
         actuarial_models: Mapping<u64, ActuarialModel>,
         model_count: u64,
 
         // Underwriting
-        underwriting_criteria: Mapping<u64, UnderwritingCriteria>, // pool_id -> criteria
+        underwriting_criteria: Mapping<u64, UnderwritingCriteria>,
 
         // Liquidity providers
         liquidity_providers: Mapping<(u64, AccountId), PoolLiquidityProvider>,
@@ -487,9 +93,8 @@ mod propchain_insurance {
 
         // Claim cooldown: property_id -> last_claim_timestamp
         claim_cooldowns: Mapping<u64, u64>,
-        // Rate limiting: caller -> last_submit_claim_timestamp (#300)
+        // Rate limiting: caller -> last_submit_claim_timestamp
         caller_last_claim: Mapping<AccountId, u64>,
-        
 
         // Evidence tracking
         evidence_count: u64,
@@ -501,327 +106,33 @@ mod propchain_insurance {
         oracle_contract: Option<AccountId>,
 
         // Platform settings
-        platform_fee_rate: u32,     // Basis points (e.g. 200 = 2%)
-        claim_cooldown_period: u64, // In seconds
+        platform_fee_rate: u32,
+        claim_cooldown_period: u64,
         min_pool_capital: u128,
-        dispute_window_seconds: u64, // #134 – window after UnderReview within which disputes can be raised
-        arbiter: Option<AccountId>,  // #134 – designated dispute arbiter (falls back to admin)
-        
+        dispute_window_seconds: u64,
+        arbiter: Option<AccountId>,
+
         // Security: track used evidence nonces to prevent replay attacks
-        used_evidence_nonces: Mapping<(u64, String), bool>, // (property_id, nonce) -> bool
-        
+        used_evidence_nonces: Mapping<(u64, String), bool>,
+
         // Emergency pause mechanism
         is_paused: bool,
-        // Time-lock for admin operations (#301)
-        // Stores the earliest timestamp at which a pending admin action may execute.
-        // None means no action is pending.
+        // Time-lock for admin operations
         pending_pause_after: Option<u64>,
         pending_admin: Option<AccountId>,
         pending_admin_after: Option<u64>,
-        /// Delay in seconds before a proposed admin action takes effect (default 86400 = 24 h)
         admin_timelock_delay: u64,
-        
+
         // Fee tracking
         total_platform_fees_collected: u128,
-        
+
         // Minimum premium to prevent rounding exploits
         min_premium_amount: u128,
     }
 
     // =========================================================================
-    // EVENTS
+    // IMPLEMENTATION  (extracted to insurance_impl.rs)
     // =========================================================================
-
-    #[ink(event)]
-    pub struct PolicyCreated {
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        policyholder: AccountId,
-        #[ink(topic)]
-        property_id: u64,
-        coverage_type: CoverageType,
-        coverage_amount: u128,
-        premium_amount: u128,
-        start_time: u64,
-        end_time: u64,
-    }
-
-    #[ink(event)]
-    pub struct PolicyIssued {
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        holder: AccountId,
-        coverage_amount: u128,
-        premium_amount: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct PolicyCancelled {
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        policyholder: AccountId,
-        cancelled_at: u64,
-        reason: Option<String>,
-    }
-
-    #[ink(event)]
-    pub struct PolicyRenewed {
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        holder: AccountId,
-        renewal_premium: u128,
-        new_end_time: u64,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct PolicyExpired {
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        holder: AccountId,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct ClaimSubmitted {
-        #[ink(topic)]
-        claim_id: u64,
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        claimant: AccountId,
-        claim_amount: u128,
-        submitted_at: u64,
-    }
-
-    #[ink(event)]
-    pub struct ClaimApproved {
-        #[ink(topic)]
-        claim_id: u64,
-        #[ink(topic)]
-        policy_id: u64,
-        payout_amount: u128,
-        approved_by: AccountId,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct ClaimRejected {
-        #[ink(topic)]
-        claim_id: u64,
-        #[ink(topic)]
-        policy_id: u64,
-        reason: String,
-        rejected_by: AccountId,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct PayoutExecuted {
-        #[ink(topic)]
-        claim_id: u64,
-        #[ink(topic)]
-        recipient: AccountId,
-        amount: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct PoolCapitalized {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct LiquidityDeposited {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        accumulated_reward_per_share: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct LiquidityWithdrawn {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        principal: u128,
-        rewards_paid: u128,
-        accumulated_reward_per_share: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct RewardsClaimed {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        accumulated_reward_per_share: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct RewardsReinvested {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        new_stake: u128,
-        accumulated_reward_per_share: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct RewardsVestingStarted {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        vesting_start: u64,
-        vesting_cliff: u64,
-        vesting_duration: u64,
-    }
-
-    #[ink(event)]
-    pub struct VestedRewardsClaimed {
-        #[ink(topic)]
-        pool_id: u64,
-        #[ink(topic)]
-        provider: AccountId,
-        amount: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct ReinsuranceActivated {
-        #[ink(topic)]
-        claim_id: u64,
-        agreement_id: u64,
-        recovery_amount: u128,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct InsuranceTokenMinted {
-        #[ink(topic)]
-        token_id: u64,
-        #[ink(topic)]
-        policy_id: u64,
-        #[ink(topic)]
-        owner: AccountId,
-        face_value: u128,
-    }
-
-    #[ink(event)]
-    pub struct InsuranceTokenTransferred {
-        #[ink(topic)]
-        token_id: u64,
-        #[ink(topic)]
-        from: AccountId,
-        #[ink(topic)]
-        to: AccountId,
-        price: u128,
-    }
-
-    #[ink(event)]
-    pub struct RiskAssessmentUpdated {
-        #[ink(topic)]
-        property_id: u64,
-        overall_score: u32,
-        risk_level: RiskLevel,
-        timestamp: u64,
-    }
-
-    #[ink(event)]
-    pub struct EvidenceSubmitted {
-        #[ink(topic)]
-        evidence_id: u64,
-        #[ink(topic)]
-        raised_by: AccountId,
-        dispute_deadline: u64,
-        previous_status: ClaimStatus,
-        timestamp: u64,
-        claim_id: u64,
-        evidence_type: String,
-        ipfs_hash: String,
-        submitter: AccountId,
-        submitted_at: u64,
-    }
-
-    #[ink(event)]
-    pub struct EvidenceVerified {
-        #[ink(topic)]
-        evidence_id: u64,
-        verified_by: AccountId,
-        is_valid: bool,
-        verified_at: u64,
-    }
-    
-    #[ink(event)]
-    pub struct ContractPaused {
-        #[ink(topic)]
-        paused_by: AccountId,
-        timestamp: u64,
-    }
-    
-    #[ink(event)]
-    pub struct ContractUnpaused {
-        #[ink(topic)]
-        unpaused_by: AccountId,
-        timestamp: u64,
-    }
-
-    /// Emitted when a pause is proposed; executes after time-lock delay (#301)
-    #[ink(event)]
-    pub struct PauseProposed {
-        #[ink(topic)]
-        proposed_by: AccountId,
-        earliest_execution: u64,
-    }
-
-    /// Emitted when a new admin is proposed; executes after time-lock delay (#301)
-    #[ink(event)]
-    pub struct AdminProposed {
-        #[ink(topic)]
-        proposed_by: AccountId,
-        #[ink(topic)]
-        new_admin: AccountId,
-        earliest_execution: u64,
-    }
-
-    /// Emitted when a pending admin change is executed (#301)
-    #[ink(event)]
-    pub struct AdminChanged {
-        #[ink(topic)]
-        old_admin: AccountId,
-        #[ink(topic)]
-        new_admin: AccountId,
-        timestamp: u64,
-    }
-
-    // =========================================================================
-    // IMPLEMENTATION
-    // =========================================================================
-
-    // Core contract behavior is extracted to keep the root module focused on types and wiring.
     include!("insurance_impl.rs");
 
     impl Default for PropertyInsurance {
@@ -836,6 +147,4 @@ pub use crate::propchain_insurance::{InsuranceError, PropertyInsurance};
 #[cfg(test)]
 mod insurance_tests {
     include!("insurance_tests.rs");
-}
-
 }

--- a/stellar-insured-contracts/contracts/insurance/src/types.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/types.rs
@@ -1,0 +1,319 @@
+use ink::prelude::{string::String, vec::Vec};
+use ink::primitives::AccountId;
+
+/// Fixed-point precision for [`RiskPool::accumulated_reward_per_share`] (1e18).
+pub const REWARD_PRECISION: u128 = 1_000_000_000_000_000_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum InsuranceError {
+    Unauthorized,
+    PolicyNotFound,
+    ClaimNotFound,
+    PoolNotFound,
+    PolicyAlreadyActive,
+    PolicyExpired,
+    PolicyInactive,
+    InsufficientPremium,
+    InsufficientPoolFunds,
+    ClaimAlreadyProcessed,
+    ClaimExceedsCoverage,
+    InvalidParameters,
+    OracleVerificationFailed,
+    ReinsuranceCapacityExceeded,
+    TokenNotFound,
+    TransferFailed,
+    CooldownPeriodActive,
+    PropertyNotInsurable,
+    DuplicateClaim,
+    InvalidEvidenceUri,
+    InvalidEvidenceHash,
+    InvalidEvidenceNonce,
+    DisputeWindowExpired,
+    InvalidDisputeTransition,
+    ContractPaused,
+    NonceAlreadyUsed,
+    PremiumTooLow,
+    EvidenceNonceEmpty,
+    EvidenceInvalidUriScheme,
+    EvidenceInvalidHashLength,
+    ZeroAmount,
+    InsufficientStake,
+    InsufficientPoolLiquidity,
+    TimeLockPending,
+    TimeLockNotReady,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PolicyStatus {
+    Active,
+    Renewed,
+    Expired,
+    Cancelled,
+    Claimed,
+    Suspended,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum PolicyType {
+    Standard,
+    Parametric,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum CoverageType {
+    Fire,
+    Flood,
+    Earthquake,
+    Theft,
+    LiabilityDamage,
+    NaturalDisaster,
+    Comprehensive,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum ClaimStatus {
+    Pending,
+    UnderReview,
+    OracleVerifying,
+    Approved,
+    Rejected,
+    Paid,
+    Disputed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum RiskLevel {
+    VeryLow,
+    Low,
+    Medium,
+    High,
+    VeryHigh,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct EvidenceMetadata {
+    pub evidence_type: String,
+    pub reference_uri: String,
+    pub content_hash: Vec<u8>,
+    pub description: Option<String>,
+}
+
+impl From<&str> for EvidenceMetadata {
+    fn from(s: &str) -> Self {
+        EvidenceMetadata {
+            evidence_type: "unknown".into(),
+            reference_uri: s.into(),
+            content_hash: vec![0u8; 32],
+            description: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct EvidenceItem {
+    pub id: u64,
+    pub claim_id: u64,
+    pub evidence_type: String,
+    pub ipfs_hash: String,
+    pub ipfs_uri: String,
+    pub content_hash: Vec<u8>,
+    pub file_size: u64,
+    pub submitter: AccountId,
+    pub submitted_at: u64,
+    pub verified: bool,
+    pub verified_by: Option<AccountId>,
+    pub verified_at: Option<u64>,
+    pub verification_notes: Option<String>,
+    pub metadata_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct EvidenceVerification {
+    pub evidence_id: u64,
+    pub verifier: AccountId,
+    pub verified_at: u64,
+    pub is_valid: bool,
+    pub notes: String,
+    pub ipfs_accessible: bool,
+    pub hash_matches: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct InsurancePolicy {
+    pub policy_id: u64,
+    pub property_id: u64,
+    pub policyholder: AccountId,
+    pub coverage_type: CoverageType,
+    pub coverage_amount: u128,
+    pub premium_amount: u128,
+    pub deductible: u128,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub status: PolicyStatus,
+    pub risk_level: RiskLevel,
+    pub pool_id: u64,
+    pub claims_count: u32,
+    pub total_claimed: u128,
+    pub metadata_url: String,
+    pub policy_type: PolicyType,
+    pub event_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct InsuranceClaim {
+    pub claim_id: u64,
+    pub policy_id: u64,
+    pub claimant: AccountId,
+    pub claim_amount: u128,
+    pub description: String,
+    pub evidence: EvidenceMetadata,
+    pub evidence_ids: Vec<u64>,
+    pub oracle_report_url: String,
+    pub status: ClaimStatus,
+    pub submitted_at: u64,
+    pub processed_at: Option<u64>,
+    pub payout_amount: u128,
+    pub assessor: Option<AccountId>,
+    pub rejection_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct RiskPool {
+    pub pool_id: u64,
+    pub name: String,
+    pub coverage_type: CoverageType,
+    pub total_capital: u128,
+    pub available_capital: u128,
+    pub total_premiums_collected: u128,
+    pub total_claims_paid: u128,
+    pub active_policies: u64,
+    pub max_coverage_ratio: u32,
+    pub reinsurance_threshold: u128,
+    pub created_at: u64,
+    pub is_active: bool,
+    pub total_provider_stake: u128,
+    pub accumulated_reward_per_share: u128,
+    pub vesting_cliff_seconds: u64,
+    pub vesting_duration_seconds: u64,
+    pub early_withdrawal_penalty_bps: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct RiskAssessment {
+    pub property_id: u64,
+    pub location_risk_score: u32,
+    pub construction_risk_score: u32,
+    pub age_risk_score: u32,
+    pub claims_history_score: u32,
+    pub overall_risk_score: u32,
+    pub risk_level: RiskLevel,
+    pub assessed_at: u64,
+    pub valid_until: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct PremiumCalculation {
+    pub base_rate: u32,
+    pub risk_multiplier: u32,
+    pub coverage_multiplier: u32,
+    pub annual_premium: u128,
+    pub monthly_premium: u128,
+    pub deductible: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct ReinsuranceAgreement {
+    pub agreement_id: u64,
+    pub reinsurer: AccountId,
+    pub coverage_limit: u128,
+    pub retention_limit: u128,
+    pub premium_ceded_rate: u32,
+    pub coverage_types: Vec<CoverageType>,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub is_active: bool,
+    pub total_ceded_premiums: u128,
+    pub total_recoveries: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct InsuranceToken {
+    pub token_id: u64,
+    pub policy_id: u64,
+    pub owner: AccountId,
+    pub face_value: u128,
+    pub is_tradeable: bool,
+    pub created_at: u64,
+    pub listed_price: Option<u128>,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct ActuarialModel {
+    pub model_id: u64,
+    pub coverage_type: CoverageType,
+    pub loss_frequency: u32,
+    pub average_loss_severity: u128,
+    pub expected_loss_ratio: u32,
+    pub confidence_level: u32,
+    pub last_updated: u64,
+    pub data_points: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct UnderwritingCriteria {
+    pub max_property_age_years: u32,
+    pub min_property_value: u128,
+    pub max_property_value: u128,
+    pub excluded_locations: Vec<String>,
+    pub required_safety_features: bool,
+    pub max_previous_claims: u32,
+    pub min_risk_score: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct BatchClaimResult {
+    pub claim_id: u64,
+    pub success: bool,
+    pub error: Option<InsuranceError>,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct BatchClaimSummary {
+    pub total_processed: u64,
+    pub successful: u64,
+    pub failed: u64,
+    pub results: Vec<BatchClaimResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct PoolLiquidityProvider {
+    pub provider: AccountId,
+    pub pool_id: u64,
+    pub provider_stake: u128,
+    pub reward_debt: u128,
+    pub deposited_at: u64,
+    pub vesting_total: u128,
+    pub vesting_claimed: u128,
+    pub vesting_start: u64,
+}


### PR DESCRIPTION
… modules

- escrow: extract types.rs, storage.rs, validation.rs; lib.rs wiring only
- bridge: extract types.rs, storage.rs, validation.rs; lib.rs wiring only update Cargo.toml to soroban-sdk (Soroban-native rewrite)
- insurance: extract inline types/errors to types.rs, inline events to events.rs lib.rs now contains only storage struct and module wiring

closes #348 