### PR TITLE
fix(validation): add zero address protection across escrow, bridge, p…

### DIFF
--- a/stellar-insured-contracts/contracts/bridge/src/lib.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/lib.rs
@@ -12,7 +12,7 @@ use types::{
     MultisigBridgeRequest, PropertyMetadata, RecoveryAction,
 };
 use validation::{
-    require_admin, require_not_paused, require_operator, require_supported_chain,
+    require_admin, require_non_zero_address, require_not_paused, require_operator, require_supported_chain,
     require_valid_signatures,
 };
 
@@ -33,6 +33,7 @@ impl PropertyBridge {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
+        require_non_zero_address(&admin);
 
         let config = BridgeConfig {
             supported_chains: supported_chains.clone(),
@@ -80,6 +81,8 @@ impl PropertyBridge {
         metadata: PropertyMetadata,
     ) -> u64 {
         caller.require_auth();
+        require_non_zero_address(&caller);
+        require_non_zero_address(&recipient);
 
         // Read config once and reuse — avoids redundant storage reads (#351, #353).
         let config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
@@ -127,6 +130,7 @@ impl PropertyBridge {
 
     pub fn sign_bridge_request(env: Env, operator: Address, request_id: u64, approve: bool) {
         operator.require_auth();
+        require_non_zero_address(&operator);
         require_operator(&env, &operator);
 
         let mut request: MultisigBridgeRequest = env
@@ -160,6 +164,7 @@ impl PropertyBridge {
 
     pub fn execute_bridge(env: Env, operator: Address, request_id: u64) {
         operator.require_auth();
+        require_non_zero_address(&operator);
         require_operator(&env, &operator);
 
         let mut request: MultisigBridgeRequest = env
@@ -237,6 +242,7 @@ impl PropertyBridge {
         recovery_action: RecoveryAction,
     ) {
         admin.require_auth();
+        require_non_zero_address(&admin);
         require_admin(&env, &admin);
 
         let mut request: MultisigBridgeRequest = env
@@ -358,6 +364,7 @@ impl PropertyBridge {
 
     pub fn set_pause(env: Env, admin: Address, paused: bool) {
         admin.require_auth();
+        require_non_zero_address(&admin);
         require_admin(&env, &admin);
 
         let mut config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
@@ -423,6 +430,8 @@ impl PropertyBridge {
 
     pub fn add_operator(env: Env, admin: Address, operator: Address) {
         admin.require_auth();
+        require_non_zero_address(&admin);
+        require_non_zero_address(&operator);
         require_admin(&env, &admin);
 
         let mut operators: Vec<Address> =
@@ -435,6 +444,8 @@ impl PropertyBridge {
 
     pub fn remove_operator(env: Env, admin: Address, operator: Address) {
         admin.require_auth();
+        require_non_zero_address(&admin);
+        require_non_zero_address(&operator);
         require_admin(&env, &admin);
 
         let operators: Vec<Address> =

--- a/stellar-insured-contracts/contracts/bridge/src/validation.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/validation.rs
@@ -50,3 +50,10 @@ pub fn require_admin(env: &Env, caller: &Address) {
         panic!("Unauthorized");
     }
 }
+
+/// Panics if `address` is zero (all bytes zero).
+pub fn require_non_zero_address(address: &Address) {
+    if address == &Address::from([0u8; 32]) {
+        panic!("Zero address not allowed");
+    }
+}

--- a/stellar-insured-contracts/contracts/escrow/src/lib.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/lib.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
 
 use storage::DataKey;
 use types::{ApprovalType, EscrowData, EscrowStatus, MultiSigConfig};
-use validation::{get_admin, require_not_paused, require_valid_multisig};
+use validation::{get_admin, require_not_paused, require_valid_multisig, require_non_zero_address};
 
 #[contract]
 pub struct AdvancedEscrow;
@@ -16,6 +16,7 @@ pub struct AdvancedEscrow;
 #[contractimpl]
 impl AdvancedEscrow {
     pub fn init(env: Env, admin: Address) {
+        require_non_zero_address(&admin);
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Already initialized");
         }
@@ -26,6 +27,7 @@ impl AdvancedEscrow {
 
     pub fn set_pause(env: Env, admin: Address, paused: bool) {
         admin.require_auth();
+        require_non_zero_address(&admin);
         // Use shared helper to read admin — one read, no duplication (#351, #353).
         if admin != get_admin(&env) {
             panic!("Unauthorized");
@@ -45,6 +47,11 @@ impl AdvancedEscrow {
     ) -> u64 {
         require_not_paused(&env);
         require_valid_multisig(required_signatures, participants.len());
+        require_non_zero_address(&buyer);
+        require_non_zero_address(&seller);
+        for participant in participants.iter() {
+            require_non_zero_address(participant);
+        }
 
         let mut count: u64 = env
             .storage()
@@ -168,6 +175,7 @@ impl AdvancedEscrow {
     pub fn sign_approval(env: Env, escrow_id: u64, approval_type: ApprovalType, signer: Address) {
         require_not_paused(&env);
         signer.require_auth();
+        require_non_zero_address(&signer);
 
         let config: MultiSigConfig = env
             .storage()

--- a/stellar-insured-contracts/contracts/escrow/src/validation.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/validation.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::Env;
+use soroban_sdk::{Address, Env};
 
 use crate::storage::DataKey;
 
@@ -15,6 +15,12 @@ pub fn require_not_paused(env: &Env) {
         .unwrap_or(false);
     if paused {
         panic!("Contract is paused");
+    }
+}
+/// Panics if `address` is zero (all bytes zero).
+pub fn require_non_zero_address(address: &Address) {
+    if address == &Address::from([0u8; 32]) {
+        panic!("Zero address not allowed");
     }
 }
 

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
@@ -2,6 +2,9 @@
         /// Initialize insurance storage, default platform settings, and the admin role.
         #[ink(constructor)]
         pub fn new(admin: AccountId) -> Self {
+            if admin == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             let mut role_manager = RoleManager::default();
             role_manager.grant(admin, Role::Admin);
             Self {
@@ -2047,6 +2050,9 @@
         #[ink(message)]
         pub fn grant_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
             self.ensure_role(Role::Admin)?;
+            if account == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.role_manager.grant(account, role);
             self.env().emit_event(RoleGranted {
                 account,
@@ -2060,6 +2066,9 @@
         #[ink(message)]
         pub fn revoke_role(&mut self, account: AccountId, role: Role) -> Result<(), InsuranceError> {
             self.ensure_role(Role::Admin)?;
+            if account == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.role_manager.revoke(account, role);
             self.env().emit_event(RoleRevoked {
                 account,
@@ -2072,18 +2081,27 @@
         /// Return `true` if `account` holds `role`. (#346)
         #[ink(message)]
         pub fn has_role(&self, account: AccountId, role: Role) -> bool {
+            if account == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.role_manager.has_role(account, role)
         }
 
         /// Return all roles held by `account`. (#346)
         #[ink(message)]
         pub fn get_roles(&self, account: AccountId) -> Vec<Role> {
+            if account == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.role_manager.roles_of(account)
         }
 
         /// Authorize an oracle address (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_oracle(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
+            if oracle == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.grant_role(oracle, Role::Oracle)
         }
 
@@ -2091,6 +2109,9 @@
         #[ink(message)]
         pub fn set_oracle_contract(&mut self, oracle: AccountId) -> Result<(), InsuranceError> {
             self.ensure_role(Role::Admin)?;
+            if oracle == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.oracle_contract = Some(oracle);
             Ok(())
         }
@@ -2098,6 +2119,9 @@
         /// Authorize a claims assessor (backwards-compatible wrapper)
         #[ink(message)]
         pub fn authorize_assessor(&mut self, assessor: AccountId) -> Result<(), InsuranceError> {
+            if assessor == AccountId::from([0x0; 32]) {
+                panic!("Zero address not allowed");
+            }
             self.grant_role(assessor, Role::Assessor)
         }
 

--- a/stellar-insured-contracts/contracts/property-token/src/lib.rs
+++ b/stellar-insured-contracts/contracts/property-token/src/lib.rs
@@ -179,9 +179,18 @@ mod property_token {
             }
         }
 
+        /// Ensure the account is not the zero address.
+        fn ensure_non_zero_account(account: &AccountId) -> Result<(), Error> {
+            if *account == AccountId::from([0x0; 32]) {
+                return Err(Error::InvalidRequest);
+            }
+            Ok(())
+        }
+
         /// ERC-721: Returns the balance of tokens owned by an account
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> u32 {
+            self.ensure_non_zero_account(&owner).unwrap_or_else(|_| panic!("Zero address not allowed"));
             self.owner_token_count.get(owner).unwrap_or(0)
         }
 
@@ -200,6 +209,8 @@ mod property_token {
             token_id: TokenId,
         ) -> Result<(), Error> {
             let caller = self.env().caller();
+            self.ensure_non_zero_account(&from)?;
+            self.ensure_non_zero_account(&to)?;
 
             // Check if caller is authorized to transfer
             let token_owner = self.token_owner.get(token_id).ok_or_else(|| {


### PR DESCRIPTION
Closes #363

## 🔒 Fix: Zero Address Protection Across Contracts

Adds zero address validation guards across escrow, bridge, property token, and insurance contracts to prevent broken logic and potential fund loss from invalid address inputs.

### Changes

**Escrow**
- Added `require_non_zero_address` helper in `validation.rs`
- `lib.rs` — validates `admin`, `buyer`, `seller`, `participants`, and `signer` on input

**Bridge**
- Added `require_non_zero_address` helper in `validation.rs`
- `lib.rs` — validates `admin`, `caller`, `recipient`, and `operator` on input

**Property Token**
- Added `ensure_non_zero_account` helper in `lib.rs`
- `balance_of` and `transfer_from` — zero address validation added

**Insurance**
- `new`, `grant_role`, `revoke_role`, `has_role`, `get_roles`, `authorize_assessor`, `authorize_oracle`, and `set_oracle_contract` — zero address validation added across all address-accepting functions

### Security
All address inputs are now rejected at the entrypoint before any state changes occur, preventing interactions with invalid or empty addresses that could corrupt logic or result in lost funds.