### PR TITLE
fix: replace storage unwrap with safe handling across contracts

### DIFF
--- a/stellar-insured-contracts/contracts/bridge/src/lib.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/lib.rs
@@ -109,7 +109,8 @@ impl PropertyBridge {
         env.storage().persistent().set(&DataKey::Nonce(caller.clone()), &nonce);
 
         // Read config once and reuse — avoids redundant storage reads (#351, #353).
-        let config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        let config: BridgeConfig = env.storage().instance().get(&DataKey::Config)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         require_not_paused(&env);
         require_supported_chain(&config, destination_chain);
         require_valid_signatures(&config, required_signatures);
@@ -307,7 +308,8 @@ impl PropertyBridge {
         require_non_zero_address(&admin);
         require_admin(&env, &admin);
 
-        let mut config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        let mut config: BridgeConfig = env.storage().instance().get(&DataKey::Config)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         config.emergency_pause = paused;
         env.storage().instance().set(&DataKey::Config, &config);
     }
@@ -319,7 +321,8 @@ impl PropertyBridge {
         require_admin(&env, &admin);
 
         let mut operators: Vec<Address> =
-            env.storage().instance().get(&DataKey::Operators).unwrap();
+            env.storage().instance().get(&DataKey::Operators)
+                .unwrap_or_else(|| panic!("Contract not initialized"));
         
         if operators.len() >= MAX_OPERATORS {
             panic!("Too many operators");
@@ -338,7 +341,8 @@ impl PropertyBridge {
         require_admin(&env, &admin);
 
         let operators: Vec<Address> =
-            env.storage().instance().get(&DataKey::Operators).unwrap();
+            env.storage().instance().get(&DataKey::Operators)
+                .unwrap_or_else(|| panic!("Contract not initialized"));
         let mut new_operators = Vec::new(&env);
         for op in operators.iter() {
             if op != operator {

--- a/stellar-insured-contracts/contracts/bridge/src/validation.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/validation.rs
@@ -9,7 +9,8 @@ use crate::types::BridgeConfig;
 /// contract's `require_not_paused` signature so all validation helpers
 /// follow the same `&Env` convention (#353).
 pub fn require_not_paused(env: &Env) {
-    let config: BridgeConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+    let config: BridgeConfig = env.storage().instance().get(&DataKey::Config)
+        .unwrap_or_else(|| panic!("Contract not initialized"));
     if config.emergency_pause {
         panic!("Bridge paused");
     }
@@ -37,7 +38,7 @@ pub fn require_operator(env: &Env, caller: &Address) {
         .storage()
         .instance()
         .get(&DataKey::Operators)
-        .unwrap();
+        .unwrap_or_else(|| panic!("Contract not initialized"));
     if !operators.contains(caller.clone()) {
         panic!("Not an operator");
     }
@@ -45,7 +46,8 @@ pub fn require_operator(env: &Env, caller: &Address) {
 
 /// Panics if `caller` is not the stored admin.
 pub fn require_admin(env: &Env, caller: &Address) {
-    let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    let admin: Address = env.storage().instance().get(&DataKey::Admin)
+        .unwrap_or_else(|| panic!("Contract not initialized"));
     if *caller != admin {
         panic!("Unauthorized");
     }

--- a/stellar-insured-contracts/contracts/claims/src/lib.rs
+++ b/stellar-insured-contracts/contracts/claims/src/lib.rs
@@ -59,7 +59,8 @@ impl ClaimsContract {
     }
 
     pub fn start_review(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
@@ -77,7 +78,8 @@ impl ClaimsContract {
     }
 
     pub fn approve_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
@@ -95,7 +97,8 @@ impl ClaimsContract {
     }
 
     pub fn reject_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
@@ -113,7 +116,8 @@ impl ClaimsContract {
     }
 
     pub fn settle_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
@@ -122,7 +126,8 @@ impl ClaimsContract {
         }
 
         // Cross-contract call to Risk Pool to payout
-        let risk_pool: Address = env.storage().instance().get(&DataKey::RiskPool).unwrap();
+        let risk_pool: Address = env.storage().instance().get(&DataKey::RiskPool)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         
         // payout_claim(recipient, amount)
         env.invoke_contract::<()>(

--- a/stellar-insured-contracts/contracts/governance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/governance/src/lib.rs
@@ -69,7 +69,8 @@ impl GovernanceContract {
         counter += 1;
         env.storage().instance().set(&DataKey::ProposalCounter, &counter);
 
-        let voting_period: u64 = env.storage().instance().get(&DataKey::VotingPeriod).unwrap();
+        let voting_period: u64 = env.storage().instance().get(&DataKey::VotingPeriod)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         
         let proposal = Proposal {
             id: counter,

--- a/stellar-insured-contracts/contracts/policy/src/lib.rs
+++ b/stellar-insured-contracts/contracts/policy/src/lib.rs
@@ -34,14 +34,16 @@ impl PolicyContract {
         duration_days: u32,
         policy_type: PolicyType,
     ) -> u64 {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut counter: u64 = env.storage().instance().get(&DataKey::PolicyCounter).unwrap_or(0);
         counter += 1;
         env.storage().instance().set(&DataKey::PolicyCounter, &counter);
 
-        let risk_pool: Address = env.storage().instance().get(&DataKey::RiskPool).unwrap();
+        let risk_pool: Address = env.storage().instance().get(&DataKey::RiskPool)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
 
         let policy = InsurancePolicy {
             policy_id: counter,

--- a/stellar-insured-contracts/contracts/risk_pool/src/lib.rs
+++ b/stellar-insured-contracts/contracts/risk_pool/src/lib.rs
@@ -43,12 +43,14 @@ impl RiskPoolContract {
     pub fn deposit_liquidity(env: Env, provider: Address, amount: i128) {
         provider.require_auth();
         
-        let min_stake: i128 = env.storage().instance().get(&DataKey::MinStake).unwrap();
+        let min_stake: i128 = env.storage().instance().get(&DataKey::MinStake)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         if amount < min_stake {
             panic!("Amount below minimum stake");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token: Address = env.storage().instance().get(&DataKey::Token)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         
         // Transfer tokens from provider to this contract
         // Note: In a real implementation, we'd use the token interface
@@ -60,8 +62,10 @@ impl RiskPoolContract {
         current_stake += amount;
         env.storage().persistent().set(&DataKey::ProviderStake(provider), &current_stake);
 
-        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital).unwrap();
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
+        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
+        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         
         total_cap += amount;
         avail_cap += amount;
@@ -80,19 +84,22 @@ impl RiskPoolContract {
             panic!("Insufficient stake");
         }
 
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
+        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         if avail_cap < amount {
             panic!("Insufficient available capital in pool");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token: Address = env.storage().instance().get(&DataKey::Token)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         let client = soroban_sdk::token::Client::new(&env, &token);
         client.transfer(&env.current_contract_address(), &provider, &amount);
 
         current_stake -= amount;
         env.storage().persistent().set(&DataKey::ProviderStake(provider), &current_stake);
 
-        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital).unwrap();
+        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         total_cap -= amount;
         avail_cap -= amount;
 
@@ -103,22 +110,26 @@ impl RiskPoolContract {
     }
 
     pub fn payout_claim(env: Env, recipient: Address, amount: i128) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
+        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         if avail_cap < amount {
             panic!("Insufficient pool funds for payout");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token: Address = env.storage().instance().get(&DataKey::Token)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         let client = soroban_sdk::token::Client::new(&env, &token);
         client.transfer(&env.current_contract_address(), &recipient, &amount);
 
         avail_cap -= amount;
         env.storage().instance().set(&DataKey::AvailableCapital, &avail_cap);
 
-        let mut paid: i128 = env.storage().instance().get(&DataKey::ClaimsPaid).unwrap();
+        let mut paid: i128 = env.storage().instance().get(&DataKey::ClaimsPaid)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         paid += amount;
         env.storage().instance().set(&DataKey::ClaimsPaid, &paid);
 

--- a/stellar-insured-contracts/contracts/slashing/src/lib.rs
+++ b/stellar-insured-contracts/contracts/slashing/src/lib.rs
@@ -50,14 +50,16 @@ impl SlashingContract {
     }
 
     pub fn configure_penalty_parameters(env: Env, role: Symbol, params: PenaltyParams) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         env.storage().persistent().set(&DataKey::PenaltyParams(role), &params);
     }
 
     pub fn slash_funds(env: Env, target: Address, role: Symbol, reason: String, amount: i128) {
-        let governance: Address = env.storage().instance().get(&DataKey::Governance).unwrap();
+        let governance: Address = env.storage().instance().get(&DataKey::Governance)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         governance.require_auth();
 
         if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
@@ -95,7 +97,8 @@ impl SlashingContract {
     }
 
     pub fn add_slashable_role(env: Env, role: Symbol) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let mut roles: Vec<Symbol> = env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(&env));
@@ -106,7 +109,8 @@ impl SlashingContract {
     }
 
     pub fn remove_slashable_role(env: Env, role: Symbol) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
 
         let roles: Vec<Symbol> = env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(&env));
@@ -147,13 +151,15 @@ impl SlashingContract {
     }
 
     pub fn pause(env: Env) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
     }
 
     pub fn unpause(env: Env) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .unwrap_or_else(|| panic!("Contract not initialized"));
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
     }


### PR DESCRIPTION
Replace all bare .unwrap() calls on storage retrieval with .unwrap_or_else(|| panic!("Contract not initialized")) to prevent silent runtime panics when storage keys are missing.

Affected contracts: claims, slashing, risk_pool, policy, governance, bridge (lib + validation).

Closes #368