### PR TITLE
fix: storage abstraction, admin audit trail, large data cap, consistency checks

### DIFF
--- a/stellar-insured-contracts/contracts/claims/src/lib.rs
+++ b/stellar-insured-contracts/contracts/claims/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, log};
-use stellar_insured_lib::{InsuranceClaim, ClaimStatus, InsurancePolicy};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+use stellar_insured_lib::{InsuranceClaim, ClaimStatus, InsurancePolicy, PolicyStatus};
 
 #[contracttype]
 #[derive(Clone)]
@@ -12,6 +12,26 @@ pub enum DataKey {
     Claim(u64),
     ClaimCounter,
 }
+
+// --- Storage helpers (#378: data access abstraction) ---
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_claim_counter(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::ClaimCounter).unwrap_or(0)
+}
+
+fn get_claim_inner(env: &Env, claim_id: u64) -> InsuranceClaim {
+    env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found")
+}
+
+fn set_claim(env: &Env, claim_id: u64, claim: &InsuranceClaim) {
+    env.storage().persistent().set(&DataKey::Claim(claim_id), claim);
+}
+
+// --------------------------------------------------------
 
 #[contract]
 pub struct ClaimsContract;
@@ -29,26 +49,41 @@ impl ClaimsContract {
     }
 
     pub fn submit_claim(env: Env, policy_id: u64, amount: i128) -> u64 {
-        // In a real scenario, we'd call PolicyContract to verify the policy exists and belongs to the caller
-        // For this modular example, we assume the caller is authorized via their address
-        
-        let mut counter: u64 = env.storage().instance().get(&DataKey::ClaimCounter).unwrap_or(0);
+        // #381: fetch policy and validate consistency before accepting claim
+        let policy_contract: Address = env.storage().instance().get(&DataKey::PolicyContract).unwrap();
+        let policy: InsurancePolicy = env.invoke_contract(
+            &policy_contract,
+            &symbol_short!("get_pol"),
+            (policy_id,).into(),
+        );
+
+        // Consistency check: policy must be active
+        if policy.status != PolicyStatus::Active && policy.status != PolicyStatus::Renewed {
+            panic!("Policy is not active");
+        }
+
+        // Consistency check: claim amount must not exceed coverage
+        if amount <= 0 || amount > policy.coverage_amount {
+            panic!("Claim amount invalid or exceeds coverage");
+        }
+
+        let claimant = policy.holder.clone();
+        claimant.require_auth();
+
+        let mut counter = get_claim_counter(&env);
         counter += 1;
         env.storage().instance().set(&DataKey::ClaimCounter, &counter);
-
-        let claimant = env.current_contract_address(); // Simplified: using contract address or passed address
-        // Ideally: policy_contract.get_policy(policy_id).holder.require_auth();
 
         let claim = InsuranceClaim {
             claim_id: counter,
             policy_id,
-            claimant: env.current_contract_address(), // Placeholder
+            claimant,
             amount,
             status: ClaimStatus::Submitted,
             submitted_at: env.ledger().timestamp(),
         };
 
-        env.storage().persistent().set(&DataKey::Claim(counter), &claim);
+        set_claim(&env, counter, &claim);
 
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("submitted")),
@@ -59,16 +94,16 @@ impl ClaimsContract {
     }
 
     pub fn start_review(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
+        let mut claim = get_claim_inner(&env, claim_id);
         if claim.status != ClaimStatus::Submitted {
             panic!("Invalid claim status for review");
         }
 
         claim.status = ClaimStatus::UnderReview;
-        env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+        set_claim(&env, claim_id, &claim);
 
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("review")),
@@ -77,16 +112,16 @@ impl ClaimsContract {
     }
 
     pub fn approve_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
+        let mut claim = get_claim_inner(&env, claim_id);
         if claim.status != ClaimStatus::UnderReview {
             panic!("Claim must be under review to approve");
         }
 
         claim.status = ClaimStatus::Approved;
-        env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+        set_claim(&env, claim_id, &claim);
 
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("approved")),
@@ -95,16 +130,16 @@ impl ClaimsContract {
     }
 
     pub fn reject_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
+        let mut claim = get_claim_inner(&env, claim_id);
         if claim.status != ClaimStatus::UnderReview {
             panic!("Claim must be under review to reject");
         }
 
         claim.status = ClaimStatus::Rejected;
-        env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+        set_claim(&env, claim_id, &claim);
 
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("rejected")),
@@ -113,18 +148,16 @@ impl ClaimsContract {
     }
 
     pub fn settle_claim(env: Env, claim_id: u64) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut claim: InsuranceClaim = env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found");
+        let mut claim = get_claim_inner(&env, claim_id);
         if claim.status != ClaimStatus::Approved {
             panic!("Only approved claims can be settled");
         }
 
-        // Cross-contract call to Risk Pool to payout
         let risk_pool: Address = env.storage().instance().get(&DataKey::RiskPool).unwrap();
-        
-        // payout_claim(recipient, amount)
+
         env.invoke_contract::<()>(
             &risk_pool,
             &symbol_short!("payout"),
@@ -132,7 +165,7 @@ impl ClaimsContract {
         );
 
         claim.status = ClaimStatus::Settled;
-        env.storage().persistent().set(&DataKey::Claim(claim_id), &claim);
+        set_claim(&env, claim_id, &claim);
 
         env.events().publish(
             (symbol_short!("claim"), symbol_short!("settled")),
@@ -141,10 +174,10 @@ impl ClaimsContract {
     }
 
     pub fn get_claim(env: Env, claim_id: u64) -> InsuranceClaim {
-        env.storage().persistent().get(&DataKey::Claim(claim_id)).expect("Claim not found")
+        get_claim_inner(&env, claim_id)
     }
 
     pub fn get_stats(env: Env) -> u64 {
-        env.storage().instance().get(&DataKey::ClaimCounter).unwrap_or(0)
+        get_claim_counter(&env)
     }
 }

--- a/stellar-insured-contracts/contracts/governance/src/lib.rs
+++ b/stellar-insured-contracts/contracts/governance/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, log, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, Symbol};
 use stellar_insured_lib::Proposal;
 
 #[contracttype]
@@ -33,6 +33,30 @@ pub struct ProposalStats {
     pub status: Symbol,
 }
 
+// --- Storage helpers (#378: data access abstraction) ---
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_voting_period(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::VotingPeriod).unwrap()
+}
+
+fn get_proposal_counter(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0)
+}
+
+fn get_proposal_inner(env: &Env, proposal_id: u64) -> Proposal {
+    env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found")
+}
+
+fn set_proposal(env: &Env, proposal_id: u64, proposal: &Proposal) {
+    env.storage().persistent().set(&DataKey::Proposal(proposal_id), proposal);
+}
+
+// --------------------------------------------------------
+
 #[contract]
 pub struct GovernanceContract;
 
@@ -53,6 +77,12 @@ impl GovernanceContract {
         env.storage().instance().set(&DataKey::SlashingContract, &slashing_contract);
         env.storage().instance().set(&DataKey::VotingPeriod, &voting_period);
         env.storage().instance().set(&DataKey::ProposalCounter, &0u64);
+
+        // #379: emit event for initialization
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("init")),
+            admin,
+        );
     }
 
     pub fn create_proposal(
@@ -65,19 +95,17 @@ impl GovernanceContract {
     ) -> u64 {
         creator.require_auth();
 
-        let mut counter: u64 = env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0);
+        let mut counter = get_proposal_counter(&env);
         counter += 1;
         env.storage().instance().set(&DataKey::ProposalCounter, &counter);
 
-        let voting_period: u64 = env.storage().instance().get(&DataKey::VotingPeriod).unwrap();
-        
         let proposal = Proposal {
             id: counter,
             title,
             description,
             execution_data,
-            creator,
-            expires_at: env.ledger().timestamp() + voting_period,
+            creator: creator.clone(),
+            expires_at: env.ledger().timestamp() + get_voting_period(&env),
             threshold_percentage,
             yes_votes: 0,
             no_votes: 0,
@@ -85,11 +113,11 @@ impl GovernanceContract {
             is_executed: false,
         };
 
-        env.storage().persistent().set(&DataKey::Proposal(counter), &proposal);
+        set_proposal(&env, counter, &proposal);
 
         env.events().publish(
             (symbol_short!("gov"), symbol_short!("created")),
-            counter,
+            (counter, creator),
         );
 
         counter
@@ -105,29 +133,43 @@ impl GovernanceContract {
         threshold: u32,
     ) -> u64 {
         creator.require_auth();
-        
-        let title = String::from_str(&env, "Slashing Proposal");
-        let mut description = String::from_str(&env, "Slash ");
-        // Simplified description construction
-        
-        // Execution data would be a serialized call to slashing contract
-        let execution_data = String::from_str(&env, "slash_call"); 
 
-        self::GovernanceContract::create_proposal(
-            env,
-            creator,
+        let title = String::from_str(&env, "Slashing Proposal");
+        let execution_data = String::from_str(&env, "slash_call");
+
+        let mut counter = get_proposal_counter(&env);
+        counter += 1;
+        env.storage().instance().set(&DataKey::ProposalCounter, &counter);
+
+        let proposal = Proposal {
+            id: counter,
             title,
-            description,
+            description: reason,
             execution_data,
-            threshold
-        )
+            creator: creator.clone(),
+            expires_at: env.ledger().timestamp() + get_voting_period(&env),
+            threshold_percentage: threshold,
+            yes_votes: 0,
+            no_votes: 0,
+            is_finalized: false,
+            is_executed: false,
+        };
+
+        set_proposal(&env, counter, &proposal);
+
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("slash_p")),
+            (counter, target, role, amount),
+        );
+
+        counter
     }
 
     pub fn vote(env: Env, voter: Address, proposal_id: u64, weight: i128, is_yes: bool) {
         voter.require_auth();
 
-        let mut proposal: Proposal = env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found");
-        
+        let mut proposal = get_proposal_inner(&env, proposal_id);
+
         if env.ledger().timestamp() > proposal.expires_at {
             panic!("Voting period ended");
         }
@@ -150,7 +192,7 @@ impl GovernanceContract {
             timestamp: env.ledger().timestamp(),
         };
 
-        env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
+        set_proposal(&env, proposal_id, &proposal);
         env.storage().persistent().set(&record_key, &record);
 
         env.events().publish(
@@ -160,14 +202,14 @@ impl GovernanceContract {
     }
 
     pub fn finalize_proposal(env: Env, proposal_id: u64) {
-        let mut proposal: Proposal = env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found");
-        
+        let mut proposal = get_proposal_inner(&env, proposal_id);
+
         if env.ledger().timestamp() <= proposal.expires_at {
             panic!("Voting period not yet ended");
         }
 
         proposal.is_finalized = true;
-        env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
+        set_proposal(&env, proposal_id, &proposal);
 
         env.events().publish(
             (symbol_short!("gov"), symbol_short!("final")),
@@ -176,8 +218,8 @@ impl GovernanceContract {
     }
 
     pub fn execute_proposal(env: Env, proposal_id: u64) {
-        let mut proposal: Proposal = env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found");
-        
+        let mut proposal = get_proposal_inner(&env, proposal_id);
+
         if !proposal.is_finalized {
             panic!("Proposal must be finalized first");
         }
@@ -192,25 +234,25 @@ impl GovernanceContract {
         }
 
         proposal.is_executed = true;
-        env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
-        
+        set_proposal(&env, proposal_id, &proposal);
+
+        // #379: emit event for admin/governance action
         env.events().publish(
-            (symbol_short!("gov"), symbol_short!("exec")),
+            (symbol_short!("admin"), symbol_short!("exec")),
             proposal_id,
         );
     }
 
     pub fn execute_slashing_proposal(env: Env, proposal_id: u64) {
-        // In a real implementation, this would parse execution_data and call slashing contract
-        self::GovernanceContract::execute_proposal(env, proposal_id);
+        Self::execute_proposal(env, proposal_id);
     }
 
     pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
-        env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found")
+        get_proposal_inner(&env, proposal_id)
     }
 
     pub fn get_active_proposals(env: Env) -> Vec<u64> {
-        let counter: u64 = env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0);
+        let counter = get_proposal_counter(&env);
         let mut list = Vec::new(&env);
         let now = env.ledger().timestamp();
         for i in 1..=counter {
@@ -224,7 +266,7 @@ impl GovernanceContract {
     }
 
     pub fn get_proposal_stats(env: Env, proposal_id: u64) -> ProposalStats {
-        let p: Proposal = env.storage().persistent().get(&DataKey::Proposal(proposal_id)).expect("Proposal not found");
+        let p = get_proposal_inner(&env, proposal_id);
         let now = env.ledger().timestamp();
         let status = if p.is_executed {
             symbol_short!("executed")
@@ -245,7 +287,7 @@ impl GovernanceContract {
     }
 
     pub fn get_all_proposals(env: Env) -> Vec<u64> {
-        let counter: u64 = env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0);
+        let counter = get_proposal_counter(&env);
         let mut list = Vec::new(&env);
         for i in 1..=counter {
             list.push_back(i);

--- a/stellar-insured-contracts/contracts/policy/src/lib.rs
+++ b/stellar-insured-contracts/contracts/policy/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, log};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 use stellar_insured_lib::{InsurancePolicy, PolicyStatus, PolicyType};
 
 #[contracttype]
@@ -11,6 +11,26 @@ pub enum DataKey {
     Policy(u64),
     PolicyCounter,
 }
+
+// --- Storage helpers (#378: data access abstraction) ---
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_policy_counter(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::PolicyCounter).unwrap_or(0)
+}
+
+fn get_policy_inner(env: &Env, policy_id: u64) -> InsurancePolicy {
+    env.storage().persistent().get(&DataKey::Policy(policy_id)).expect("Policy not found")
+}
+
+fn set_policy(env: &Env, policy_id: u64, policy: &InsurancePolicy) {
+    env.storage().persistent().set(&DataKey::Policy(policy_id), policy);
+}
+
+// --------------------------------------------------------
 
 #[contract]
 pub struct PolicyContract;
@@ -34,10 +54,10 @@ impl PolicyContract {
         duration_days: u32,
         policy_type: PolicyType,
     ) -> u64 {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut counter: u64 = env.storage().instance().get(&DataKey::PolicyCounter).unwrap_or(0);
+        let mut counter = get_policy_counter(&env);
         counter += 1;
         env.storage().instance().set(&DataKey::PolicyCounter, &counter);
 
@@ -55,7 +75,7 @@ impl PolicyContract {
             risk_pool,
         };
 
-        env.storage().persistent().set(&DataKey::Policy(counter), &policy);
+        set_policy(&env, counter, &policy);
 
         env.events().publish(
             (symbol_short!("policy"), symbol_short!("issued")),
@@ -66,11 +86,16 @@ impl PolicyContract {
     }
 
     pub fn get_policy(env: Env, policy_id: u64) -> InsurancePolicy {
-        env.storage().persistent().get(&DataKey::Policy(policy_id)).expect("Policy not found")
+        get_policy_inner(&env, policy_id)
+    }
+
+    // Alias used by claims contract cross-contract call
+    pub fn get_pol(env: Env, policy_id: u64) -> InsurancePolicy {
+        get_policy_inner(&env, policy_id)
     }
 
     pub fn renew_policy(env: Env, policy_id: u64, duration_days: u32) {
-        let mut policy: InsurancePolicy = env.storage().persistent().get(&DataKey::Policy(policy_id)).expect("Policy not found");
+        let mut policy = get_policy_inner(&env, policy_id);
         policy.holder.require_auth();
 
         if policy.status != PolicyStatus::Active && policy.status != PolicyStatus::Renewed {
@@ -80,7 +105,7 @@ impl PolicyContract {
         policy.duration_days += duration_days;
         policy.status = PolicyStatus::Renewed;
 
-        env.storage().persistent().set(&DataKey::Policy(policy_id), &policy);
+        set_policy(&env, policy_id, &policy);
 
         env.events().publish(
             (symbol_short!("policy"), symbol_short!("renewed")),
@@ -89,11 +114,11 @@ impl PolicyContract {
     }
 
     pub fn cancel_policy(env: Env, policy_id: u64) {
-        let mut policy: InsurancePolicy = env.storage().persistent().get(&DataKey::Policy(policy_id)).expect("Policy not found");
+        let mut policy = get_policy_inner(&env, policy_id);
         policy.holder.require_auth();
 
         policy.status = PolicyStatus::Cancelled;
-        env.storage().persistent().set(&DataKey::Policy(policy_id), &policy);
+        set_policy(&env, policy_id, &policy);
 
         env.events().publish(
             (symbol_short!("policy"), symbol_short!("cancelled")),
@@ -102,8 +127,8 @@ impl PolicyContract {
     }
 
     pub fn expire_policy(env: Env, policy_id: u64) {
-        let mut policy: InsurancePolicy = env.storage().persistent().get(&DataKey::Policy(policy_id)).expect("Policy not found");
-        
+        let mut policy = get_policy_inner(&env, policy_id);
+
         let now = env.ledger().timestamp();
         let expiry = policy.start_time + (policy.duration_days as u64 * 86400);
 
@@ -112,7 +137,7 @@ impl PolicyContract {
         }
 
         policy.status = PolicyStatus::Expired;
-        env.storage().persistent().set(&DataKey::Policy(policy_id), &policy);
+        set_policy(&env, policy_id, &policy);
 
         env.events().publish(
             (symbol_short!("policy"), symbol_short!("expired")),
@@ -121,6 +146,6 @@ impl PolicyContract {
     }
 
     pub fn get_stats(env: Env) -> u64 {
-        env.storage().instance().get(&DataKey::PolicyCounter).unwrap_or(0)
+        get_policy_counter(&env)
     }
 }

--- a/stellar-insured-contracts/contracts/risk_pool/src/lib.rs
+++ b/stellar-insured-contracts/contracts/risk_pool/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, log};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[contracttype]
 #[derive(Clone)]
@@ -12,7 +12,6 @@ pub enum DataKey {
     AvailableCapital,
     ClaimsPaid,
     ProviderStake(Address),
-    Providers,
 }
 
 #[contracttype]
@@ -22,6 +21,30 @@ pub struct PoolStats {
     pub available_capital: i128,
     pub total_claims_paid: i128,
 }
+
+// --- Storage helpers (#378: data access abstraction) ---
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_token(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Token).unwrap()
+}
+
+fn get_total_capital(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::TotalCapital).unwrap_or(0)
+}
+
+fn get_available_capital(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::AvailableCapital).unwrap_or(0)
+}
+
+fn get_provider_stake(env: &Env, provider: &Address) -> i128 {
+    env.storage().persistent().get(&DataKey::ProviderStake(provider.clone())).unwrap_or(0)
+}
+
+// --------------------------------------------------------
 
 #[contract]
 pub struct RiskPoolContract;
@@ -42,32 +65,20 @@ impl RiskPoolContract {
 
     pub fn deposit_liquidity(env: Env, provider: Address, amount: i128) {
         provider.require_auth();
-        
+
         let min_stake: i128 = env.storage().instance().get(&DataKey::MinStake).unwrap();
         if amount < min_stake {
             panic!("Amount below minimum stake");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        
-        // Transfer tokens from provider to this contract
-        // Note: In a real implementation, we'd use the token interface
-        // For this demo, we assume the token is a standard SAC
-        let client = soroban_sdk::token::Client::new(&env, &token);
+        let client = soroban_sdk::token::Client::new(&env, &get_token(&env));
         client.transfer(&provider, &env.current_contract_address(), &amount);
 
-        let mut current_stake: i128 = env.storage().persistent().get(&DataKey::ProviderStake(provider.clone())).unwrap_or(0);
-        current_stake += amount;
-        env.storage().persistent().set(&DataKey::ProviderStake(provider), &current_stake);
+        let new_stake = get_provider_stake(&env, &provider) + amount;
+        env.storage().persistent().set(&DataKey::ProviderStake(provider), &new_stake);
 
-        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital).unwrap();
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
-        
-        total_cap += amount;
-        avail_cap += amount;
-
-        env.storage().instance().set(&DataKey::TotalCapital, &total_cap);
-        env.storage().instance().set(&DataKey::AvailableCapital, &avail_cap);
+        env.storage().instance().set(&DataKey::TotalCapital, &(get_total_capital(&env) + amount));
+        env.storage().instance().set(&DataKey::AvailableCapital, &(get_available_capital(&env) + amount));
 
         env.events().publish((symbol_short!("pool"), symbol_short!("deposit")), amount);
     }
@@ -75,65 +86,55 @@ impl RiskPoolContract {
     pub fn withdraw_liquidity(env: Env, provider: Address, amount: i128) {
         provider.require_auth();
 
-        let mut current_stake: i128 = env.storage().persistent().get(&DataKey::ProviderStake(provider.clone())).unwrap_or(0);
-        if current_stake < amount {
+        let stake = get_provider_stake(&env, &provider);
+        if stake < amount {
             panic!("Insufficient stake");
         }
 
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
-        if avail_cap < amount {
+        let avail = get_available_capital(&env);
+        if avail < amount {
             panic!("Insufficient available capital in pool");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let client = soroban_sdk::token::Client::new(&env, &token);
+        let client = soroban_sdk::token::Client::new(&env, &get_token(&env));
         client.transfer(&env.current_contract_address(), &provider, &amount);
 
-        current_stake -= amount;
-        env.storage().persistent().set(&DataKey::ProviderStake(provider), &current_stake);
-
-        let mut total_cap: i128 = env.storage().instance().get(&DataKey::TotalCapital).unwrap();
-        total_cap -= amount;
-        avail_cap -= amount;
-
-        env.storage().instance().set(&DataKey::TotalCapital, &total_cap);
-        env.storage().instance().set(&DataKey::AvailableCapital, &avail_cap);
+        env.storage().persistent().set(&DataKey::ProviderStake(provider), &(stake - amount));
+        env.storage().instance().set(&DataKey::TotalCapital, &(get_total_capital(&env) - amount));
+        env.storage().instance().set(&DataKey::AvailableCapital, &(avail - amount));
 
         env.events().publish((symbol_short!("pool"), symbol_short!("withdraw")), amount);
     }
 
     pub fn payout_claim(env: Env, recipient: Address, amount: i128) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut avail_cap: i128 = env.storage().instance().get(&DataKey::AvailableCapital).unwrap();
-        if avail_cap < amount {
+        let avail = get_available_capital(&env);
+        if avail < amount {
             panic!("Insufficient pool funds for payout");
         }
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let client = soroban_sdk::token::Client::new(&env, &token);
+        let client = soroban_sdk::token::Client::new(&env, &get_token(&env));
         client.transfer(&env.current_contract_address(), &recipient, &amount);
 
-        avail_cap -= amount;
-        env.storage().instance().set(&DataKey::AvailableCapital, &avail_cap);
+        env.storage().instance().set(&DataKey::AvailableCapital, &(avail - amount));
 
-        let mut paid: i128 = env.storage().instance().get(&DataKey::ClaimsPaid).unwrap();
-        paid += amount;
-        env.storage().instance().set(&DataKey::ClaimsPaid, &paid);
+        let paid: i128 = env.storage().instance().get(&DataKey::ClaimsPaid).unwrap_or(0);
+        env.storage().instance().set(&DataKey::ClaimsPaid, &(paid + amount));
 
         env.events().publish((symbol_short!("pool"), symbol_short!("payout")), amount);
     }
 
     pub fn get_pool_stats(env: Env) -> PoolStats {
         PoolStats {
-            total_capital: env.storage().instance().get(&DataKey::TotalCapital).unwrap_or(0),
-            available_capital: env.storage().instance().get(&DataKey::AvailableCapital).unwrap_or(0),
+            total_capital: get_total_capital(&env),
+            available_capital: get_available_capital(&env),
             total_claims_paid: env.storage().instance().get(&DataKey::ClaimsPaid).unwrap_or(0),
         }
     }
 
     pub fn get_provider_info(env: Env, provider: Address) -> i128 {
-        env.storage().persistent().get(&DataKey::ProviderStake(provider)).unwrap_or(0)
+        get_provider_stake(&env, &provider)
     }
 }

--- a/stellar-insured-contracts/contracts/slashing/src/lib.rs
+++ b/stellar-insured-contracts/contracts/slashing/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, Symbol, Map};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, Symbol};
+
+// Maximum slashing history entries per (target, role) to prevent storage bloat (#380)
+const MAX_HISTORY: u32 = 50;
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,9 +11,9 @@ pub enum DataKey {
     Admin,
     Governance,
     RiskPool,
-    PenaltyParams(Symbol), // Role -> Params
-    ViolationCount(Address, Symbol), // (Target, Role) -> Count
-    History(Address, Symbol), // (Target, Role) -> History
+    PenaltyParams(Symbol),
+    ViolationCount(Address, Symbol),
+    History(Address, Symbol),
     SlashableRoles,
     Paused,
 }
@@ -33,6 +36,38 @@ pub struct SlashingRecord {
     pub timestamp: u64,
 }
 
+// --- Storage helpers (#378: data access abstraction) ---
+
+fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+fn get_governance(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Governance).unwrap()
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+}
+
+fn get_slashable_roles(env: &Env) -> Vec<Symbol> {
+    env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(env))
+}
+
+fn get_violation_count_inner(env: &Env, target: &Address, role: &Symbol) -> u32 {
+    env.storage().persistent().get(&DataKey::ViolationCount(target.clone(), role.clone())).unwrap_or(0)
+}
+
+fn get_history_inner(env: &Env, target: &Address, role: &Symbol) -> Vec<SlashingRecord> {
+    env.storage().persistent().get(&DataKey::History(target.clone(), role.clone())).unwrap_or(Vec::new(env))
+}
+
+fn set_history(env: &Env, target: &Address, role: &Symbol, history: &Vec<SlashingRecord>) {
+    env.storage().persistent().set(&DataKey::History(target.clone(), role.clone()), history);
+}
+
+// --------------------------------------------------------
+
 #[contract]
 pub struct SlashingContract;
 
@@ -50,26 +85,31 @@ impl SlashingContract {
     }
 
     pub fn configure_penalty_parameters(env: Env, role: Symbol, params: PenaltyParams) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        env.storage().persistent().set(&DataKey::PenaltyParams(role), &params);
+        env.storage().persistent().set(&DataKey::PenaltyParams(role.clone()), &params);
+
+        // #379: emit event for admin action
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("cfg_pen")),
+            role,
+        );
     }
 
     pub fn slash_funds(env: Env, target: Address, role: Symbol, reason: String, amount: i128) {
-        let governance: Address = env.storage().instance().get(&DataKey::Governance).unwrap();
+        let governance = get_governance(&env);
         governance.require_auth();
 
-        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+        if is_paused(&env) {
             panic!("Contract paused");
         }
 
-        if !self::SlashingContract::can_be_slashed(env.clone(), target.clone(), role.clone()) {
+        if !Self::can_be_slashed(env.clone(), target.clone(), role.clone()) {
             panic!("Target not eligible for slashing");
         }
 
-        // Record violation
-        let mut count: u32 = env.storage().persistent().get(&DataKey::ViolationCount(target.clone(), role.clone())).unwrap_or(0);
+        let mut count = get_violation_count_inner(&env, &target, &role);
         count += 1;
         env.storage().persistent().set(&DataKey::ViolationCount(target.clone(), role.clone()), &count);
 
@@ -81,13 +121,19 @@ impl SlashingContract {
             timestamp: env.ledger().timestamp(),
         };
 
-        let mut history: Vec<SlashingRecord> = env.storage().persistent().get(&DataKey::History(target.clone(), role.clone())).unwrap_or(Vec::new(&env));
+        // #380: cap history to MAX_HISTORY entries to prevent storage bloat
+        let mut history = get_history_inner(&env, &target, &role);
+        if history.len() >= MAX_HISTORY {
+            // Remove oldest entry (index 0)
+            let mut trimmed = Vec::new(&env);
+            for i in 1..history.len() {
+                trimmed.push_back(history.get(i).unwrap());
+            }
+            history = trimmed;
+        }
         history.push_back(record);
-        env.storage().persistent().set(&DataKey::History(target, role.clone()), &history);
+        set_history(&env, &target, &role, &history);
 
-        // Notify risk pool or transfer funds
-        // risk_pool.slash_stake(target, amount)
-        
         env.events().publish(
             (symbol_short!("slash"), role),
             amount,
@@ -95,21 +141,27 @@ impl SlashingContract {
     }
 
     pub fn add_slashable_role(env: Env, role: Symbol) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut roles: Vec<Symbol> = env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(&env));
+        let mut roles = get_slashable_roles(&env);
         if !roles.contains(role.clone()) {
-            roles.push_back(role);
+            roles.push_back(role.clone());
             env.storage().instance().set(&DataKey::SlashableRoles, &roles);
         }
+
+        // #379: emit event for admin action
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("role_add")),
+            role,
+        );
     }
 
     pub fn remove_slashable_role(env: Env, role: Symbol) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let roles: Vec<Symbol> = env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(&env));
+        let roles = get_slashable_roles(&env);
         let mut new_roles = Vec::new(&env);
         for r in roles.iter() {
             if r != role {
@@ -117,25 +169,30 @@ impl SlashingContract {
             }
         }
         env.storage().instance().set(&DataKey::SlashableRoles, &new_roles);
+
+        // #379: emit event for admin action
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("role_rm")),
+            role,
+        );
     }
 
     pub fn get_slashing_history(env: Env, target: Address, role: Symbol) -> Vec<SlashingRecord> {
-        env.storage().persistent().get(&DataKey::History(target, role)).unwrap_or(Vec::new(&env))
+        get_history_inner(&env, &target, &role)
     }
 
     pub fn get_violation_count(env: Env, target: Address, role: Symbol) -> u32 {
-        env.storage().persistent().get(&DataKey::ViolationCount(target, role)).unwrap_or(0)
+        get_violation_count_inner(&env, &target, &role)
     }
 
     pub fn can_be_slashed(env: Env, target: Address, role: Symbol) -> bool {
-        let roles: Vec<Symbol> = env.storage().instance().get(&DataKey::SlashableRoles).unwrap_or(Vec::new(&env));
+        let roles = get_slashable_roles(&env);
         if !roles.contains(role.clone()) {
             return false;
         }
 
-        // Check cooldown
         if let Some(params) = env.storage().persistent().get::<DataKey, PenaltyParams>(&DataKey::PenaltyParams(role.clone())) {
-            let history = self::SlashingContract::get_slashing_history(env.clone(), target, role);
+            let history = get_history_inner(&env, &target, &role);
             if let Some(last) = history.last() {
                 if env.ledger().timestamp() < last.timestamp + params.cooldown_seconds {
                     return false;
@@ -147,14 +204,26 @@ impl SlashingContract {
     }
 
     pub fn pause(env: Env) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+
+        // #379: emit event for admin action
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("paused")),
+            true,
+        );
     }
 
     pub fn unpause(env: Env) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+
+        // #379: emit event for admin action
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("paused")),
+            false,
+        );
     }
 }


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to dzekojohn4 in a single PR.

---

### #378 — Missing Data Access Abstraction
Wrapped all direct `env.storage()` calls in named helper functions across `claims`, `policy`, `risk_pool`, `governance`, and `slashing` contracts (e.g. `get_admin`, `get_claim_inner`, `set_claim`, `get_provider_stake`, etc.).

### #379 — No Audit Trail for Admin Actions
Added `env.events().publish` calls for every admin-only operation: `pause`/`unpause`, `add_slashable_role`/`remove_slashable_role`, `configure_penalty_parameters` (slashing), `initialize` and `execute_proposal` (governance).

### #380 — Improper Handling of Large Data Structures
Introduced `MAX_HISTORY = 50` constant in the slashing contract. When the history `Vec` for a `(target, role)` pair reaches the cap, the oldest entry is evicted before appending the new record, bounding storage growth.

### #381 — Missing Consistency Checks Between Related Data
`submit_claim` now cross-contract-calls the policy contract to fetch the policy before accepting a claim, then validates:
- Policy status is `Active` or `Renewed`
- Claim amount is positive and does not exceed `coverage_amount`
- Claimant is the policy holder (via `require_auth`)

---

Closes #378
Closes #379
Closes #380
Closes #381