### PR TITLE
feat: #359 Missing Boundary Checks

### DIFF
--- a/stellar-insured-contracts/.gitignore
+++ b/stellar-insured-contracts/.gitignore
@@ -134,3 +134,4 @@ rustfmt.toml.backup
 # Local configuration
 config/
 local.toml
+.codex

--- a/stellar-insured-contracts/contracts/bridge/src/lib.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/lib.rs
@@ -12,7 +12,8 @@ use types::{
     MultisigBridgeRequest, PropertyMetadata, RecoveryAction,
 };
 use validation::{
-    require_admin, require_non_zero_address, require_not_paused, require_operator, require_supported_chain,
+    require_admin, require_non_zero_address, require_non_zero_u128, require_non_zero_u32,
+    require_non_zero_u64, require_not_paused, require_operator, require_supported_chain,
     require_valid_signatures,
 };
 
@@ -38,9 +39,22 @@ impl PropertyBridge {
             panic!("Already initialized");
         }
         require_non_zero_address(&admin);
+        if supported_chains.is_empty() {
+            panic!("At least one supported chain is required");
+        }
+        require_non_zero_u32(min_signatures, "min_signatures");
+        require_non_zero_u32(max_signatures, "max_signatures");
+        require_non_zero_u64(default_timeout, "default_timeout");
+        require_non_zero_u64(gas_limit, "gas_limit");
 
         if supported_chains.len() > MAX_SUPPORTED_CHAINS {
             panic!("Too many chains");
+        }
+        for chain_id in supported_chains.iter() {
+            require_non_zero_u32(chain_id, "supported_chain");
+        }
+        if min_signatures > max_signatures {
+            panic!("min_signatures cannot exceed max_signatures");
         }
 
         let config = BridgeConfig {
@@ -105,6 +119,13 @@ impl PropertyBridge {
         caller.require_auth();
         require_non_zero_address(&caller);
         require_non_zero_address(&recipient);
+        require_non_zero_u64(token_id, "token_id");
+        require_non_zero_u32(required_signatures, "required_signatures");
+        require_non_zero_u64(metadata.size, "metadata.size");
+        require_non_zero_u128(metadata.valuation, "metadata.valuation");
+        if let Some(blocks) = timeout_blocks {
+            require_non_zero_u64(blocks, "timeout_blocks");
+        }
 
         // Nonce validation for replay protection (#349)
         let current_nonce: u64 = env.storage().persistent().get(&DataKey::Nonce(caller.clone())).unwrap_or(0);
@@ -161,6 +182,7 @@ impl PropertyBridge {
     pub fn sign_bridge_request(env: Env, operator: Address, request_id: u64, approve: bool) {
         operator.require_auth();
         require_non_zero_address(&operator);
+        require_non_zero_u64(request_id, "request_id");
         require_operator(&env, &operator);
         require_not_paused(&env);
 
@@ -201,6 +223,7 @@ impl PropertyBridge {
     pub fn execute_bridge(env: Env, operator: Address, request_id: u64) {
         operator.require_auth();
         require_non_zero_address(&operator);
+        require_non_zero_u64(request_id, "request_id");
         require_operator(&env, &operator);
         require_not_paused(&env);
 
@@ -280,6 +303,7 @@ impl PropertyBridge {
     ) {
         admin.require_auth();
         require_non_zero_address(&admin);
+        require_non_zero_u64(request_id, "request_id");
         require_admin(&env, &admin);
         require_not_paused(&env);
 

--- a/stellar-insured-contracts/contracts/bridge/src/validation.rs
+++ b/stellar-insured-contracts/contracts/bridge/src/validation.rs
@@ -9,7 +9,10 @@ use crate::types::BridgeConfig;
 /// contract's `require_not_paused` signature so all validation helpers
 /// follow the same `&Env` convention (#353).
 pub fn require_not_paused(env: &Env) {
-    let config: BridgeConfig = env.storage().instance().get(&DataKey::Config)
+    let config: BridgeConfig = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
         .unwrap_or_else(|| panic!("Contract not initialized"));
     if config.emergency_pause {
         panic!("Bridge paused");
@@ -46,7 +49,10 @@ pub fn require_operator(env: &Env, caller: &Address) {
 
 /// Panics if `caller` is not the stored admin.
 pub fn require_admin(env: &Env, caller: &Address) {
-    let admin: Address = env.storage().instance().get(&DataKey::Admin)
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
         .unwrap_or_else(|| panic!("Contract not initialized"));
     if *caller != admin {
         panic!("Unauthorized");
@@ -57,5 +63,26 @@ pub fn require_admin(env: &Env, caller: &Address) {
 pub fn require_non_zero_address(address: &Address) {
     if address == &Address::from([0u8; 32]) {
         panic!("Zero address not allowed");
+    }
+}
+
+/// Panics if the value is zero.
+pub fn require_non_zero_u32(value: u32, field: &str) {
+    if value == 0 {
+        panic!("{} must be greater than zero", field);
+    }
+}
+
+/// Panics if the value is zero.
+pub fn require_non_zero_u64(value: u64, field: &str) {
+    if value == 0 {
+        panic!("{} must be greater than zero", field);
+    }
+}
+
+/// Panics if the value is zero.
+pub fn require_non_zero_u128(value: u128, field: &str) {
+    if value == 0 {
+        panic!("{} must be greater than zero", field);
     }
 }

--- a/stellar-insured-contracts/contracts/escrow/src/lib.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/lib.rs
@@ -8,7 +8,10 @@ use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Vec};
 
 use storage::DataKey;
 use types::{ApprovalType, EscrowData, EscrowStatus, MultiSigConfig};
-use validation::{get_admin, require_not_paused, require_valid_multisig, require_non_zero_address};
+use validation::{
+    get_admin, require_future_timestamp, require_non_zero_address, require_non_zero_u64,
+    require_not_paused, require_positive_amount, require_valid_multisig,
+};
 
 const CONTRACT_VERSION: u32 = 1;
 const MAX_PARTICIPANTS: u32 = 10;
@@ -24,14 +27,14 @@ impl AdvancedEscrow {
             panic!("Already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Version, &CONTRACT_VERSION);
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &CONTRACT_VERSION);
         env.storage().instance().set(&DataKey::EscrowCount, &0u64);
         env.storage().instance().set(&DataKey::Paused, &false);
-        
-        env.events().publish(
-            (symbol_short!("escrow"), symbol_short!("init")),
-            admin,
-        );
+
+        env.events()
+            .publish((symbol_short!("escrow"), symbol_short!("init")), admin);
     }
 
     pub fn version(env: Env) -> u32 {
@@ -49,11 +52,9 @@ impl AdvancedEscrow {
             panic!("Unauthorized");
         }
         env.storage().instance().set(&DataKey::Paused, &paused);
-        
-        env.events().publish(
-            (symbol_short!("escrow"), symbol_short!("pause")),
-            paused,
-        );
+
+        env.events()
+            .publish((symbol_short!("escrow"), symbol_short!("pause")), paused);
     }
 
     pub fn create_escrow_advanced(
@@ -68,13 +69,21 @@ impl AdvancedEscrow {
         nonce: u64,
     ) -> u64 {
         require_not_paused(&env);
+        require_non_zero_u64(property_id, "property_id");
+        require_positive_amount(amount, "amount");
 
         // Nonce validation for replay protection (#349)
-        let current_nonce: u64 = env.storage().persistent().get(&DataKey::Nonce(buyer.clone())).unwrap_or(0);
+        let current_nonce: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Nonce(buyer.clone()))
+            .unwrap_or(0);
         if nonce != current_nonce + 1 {
             panic!("Invalid nonce");
         }
-        env.storage().persistent().set(&DataKey::Nonce(buyer.clone()), &nonce);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Nonce(buyer.clone()), &nonce);
 
         if participants.len() > MAX_PARTICIPANTS {
             panic!("Too many participants");
@@ -84,6 +93,9 @@ impl AdvancedEscrow {
         require_non_zero_address(&seller);
         for participant in participants.iter() {
             require_non_zero_address(participant);
+        }
+        if let Some(time_lock) = release_time_lock {
+            require_future_timestamp(time_lock, env.ledger().timestamp(), "release_time_lock");
         }
 
         let mut count: u64 = env
@@ -129,6 +141,8 @@ impl AdvancedEscrow {
 
     pub fn deposit_funds(env: Env, escrow_id: u64, amount: i128) {
         require_not_paused(&env);
+        require_non_zero_u64(escrow_id, "escrow_id");
+        require_positive_amount(amount, "amount");
 
         let mut escrow: EscrowData = env
             .storage()
@@ -139,8 +153,15 @@ impl AdvancedEscrow {
         if escrow.status != EscrowStatus::Created && escrow.status != EscrowStatus::Funded {
             panic!("Invalid status");
         }
+        let new_deposit_total = escrow
+            .deposited_amount
+            .checked_add(amount)
+            .unwrap_or_else(|| panic!("Deposit exceeds escrow amount"));
+        if new_deposit_total > escrow.amount {
+            panic!("Deposit exceeds escrow amount");
+        }
 
-        escrow.deposited_amount += amount;
+        escrow.deposited_amount = new_deposit_total;
         escrow.status = if escrow.deposited_amount >= escrow.amount {
             EscrowStatus::Active
         } else {
@@ -160,6 +181,7 @@ impl AdvancedEscrow {
 
     pub fn release_funds(env: Env, escrow_id: u64) {
         require_not_paused(&env);
+        require_non_zero_u64(escrow_id, "escrow_id");
 
         let mut escrow: EscrowData = env
             .storage()
@@ -207,6 +229,7 @@ impl AdvancedEscrow {
 
     pub fn sign_approval(env: Env, escrow_id: u64, approval_type: ApprovalType, signer: Address) {
         require_not_paused(&env);
+        require_non_zero_u64(escrow_id, "escrow_id");
         signer.require_auth();
         require_non_zero_address(&signer);
 
@@ -220,11 +243,11 @@ impl AdvancedEscrow {
             panic!("Unauthorized");
         }
 
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::Signature(escrow_id, approval_type, signer.clone()))
-        {
+        if env.storage().persistent().has(&DataKey::Signature(
+            escrow_id,
+            approval_type,
+            signer.clone(),
+        )) {
             panic!("Already signed");
         }
 
@@ -243,7 +266,7 @@ impl AdvancedEscrow {
         env.storage()
             .persistent()
             .set(&DataKey::SigCount(escrow_id, approval_type), &count);
-        
+
         env.events().publish(
             (symbol_short!("escrow"), symbol_short!("signed")),
             (escrow_id, signer, count),

--- a/stellar-insured-contracts/contracts/escrow/src/validation.rs
+++ b/stellar-insured-contracts/contracts/escrow/src/validation.rs
@@ -24,12 +24,31 @@ pub fn require_non_zero_address(address: &Address) {
     }
 }
 
+/// Panics if the identifier is zero.
+pub fn require_non_zero_u64(value: u64, field: &str) {
+    if value == 0 {
+        panic!("{} must be greater than zero", field);
+    }
+}
+
+/// Panics if the amount is zero or negative.
+pub fn require_positive_amount(amount: i128, field: &str) {
+    if amount <= 0 {
+        panic!("{} must be greater than zero", field);
+    }
+}
+
+/// Panics if `timestamp` is in the past or present relative to `now`.
+pub fn require_future_timestamp(timestamp: u64, now: u64, field: &str) {
+    if timestamp <= now {
+        panic!("{} must be in the future", field);
+    }
+}
+
 /// Panics if `required_signatures` is zero, `participants` is empty,
 /// or `required_signatures` exceeds the number of participants.
 pub fn require_valid_multisig(required_signatures: u32, participant_count: u32) {
-    if required_signatures == 0
-        || participant_count == 0
-        || required_signatures > participant_count
+    if required_signatures == 0 || participant_count == 0 || required_signatures > participant_count
     {
         panic!("Invalid configuration");
     }

--- a/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/stellar-insured-contracts/contracts/insurance/src/insurance_impl.rs
@@ -208,6 +208,9 @@
             pub fn renew_policy(&mut self, policy_id: u64, duration_seconds: u64) -> Result<(), InsuranceError> {
                 let caller = self.env().caller();
                 let paid = self.env().transferred_value();
+                if duration_seconds == 0 {
+                    return Err(InsuranceError::InvalidParameters);
+                }
                 if paid == 0 {
                     return Err(InsuranceError::InsufficientPremium);
                 }
@@ -271,6 +274,15 @@
         ) -> Result<(), InsuranceError> {
             self.ensure_role(Role::Admin)?;
             let mut pool = self.pools.get(&pool_id).ok_or(InsuranceError::PoolNotFound)?;
+            if vesting_duration_seconds == 0 {
+                if vesting_cliff_seconds != 0 || early_withdrawal_penalty_bps != 0 {
+                    return Err(InsuranceError::InvalidParameters);
+                }
+            } else if vesting_cliff_seconds > vesting_duration_seconds
+                || early_withdrawal_penalty_bps > 10_000
+            {
+                return Err(InsuranceError::InvalidParameters);
+            }
             pool.vesting_cliff_seconds = vesting_cliff_seconds;
             pool.vesting_duration_seconds = vesting_duration_seconds;
             pool.early_withdrawal_penalty_bps = early_withdrawal_penalty_bps;
@@ -716,6 +728,15 @@
             if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
+            if property_id == 0
+                || location_score > 100
+                || construction_score > 100
+                || age_score > 100
+                || claims_history_score > 100
+                || valid_for_seconds == 0
+            {
+                return Err(InsuranceError::InvalidParameters);
+            }
 
             let overall = (location_score
                 .saturating_add(construction_score)
@@ -759,6 +780,9 @@
             coverage_amount: u128,
             coverage_type: CoverageType,
         ) -> Result<PremiumCalculation, InsuranceError> {
+            if property_id == 0 || coverage_amount == 0 {
+                return Err(InsuranceError::InvalidParameters);
+            }
             let assessment = self
                 .risk_assessments
                 .get(&property_id)
@@ -820,6 +844,9 @@
             // Check if contract is paused
             if self.is_paused {
                 return Err(InsuranceError::ContractPaused);
+            }
+            if property_id == 0 || coverage_amount == 0 || duration_seconds == 0 {
+                return Err(InsuranceError::InvalidParameters);
             }
 
             // Validate pool
@@ -957,6 +984,9 @@
             event_id: u64,
             metadata_url: String,
         ) -> Result<u64, InsuranceError> {
+            if event_id == 0 {
+                return Err(InsuranceError::InvalidParameters);
+            }
             let policy_id = self.create_policy(
                 property_id,
                 coverage_type,
@@ -1544,8 +1574,14 @@
             let now = self.env().block_timestamp();
 
             // Validate evidence type
+            if claim_id == 0 {
+                return Err(InsuranceError::InvalidParameters);
+            }
             if evidence_type.is_empty() {
                 return Err(InsuranceError::EvidenceNonceEmpty);
+            }
+            if file_size == 0 {
+                return Err(InsuranceError::InvalidParameters);
             }
 
             // Validate IPFS hash format (should start with Qm or similar)
@@ -1849,6 +1885,17 @@
             duration_seconds: u64,
         ) -> Result<u64, InsuranceError> {
             self.ensure_role(Role::Admin)?;
+            if reinsurer == AccountId::from([0x0; 32])
+                || coverage_limit == 0
+                || retention_limit == 0
+                || retention_limit > coverage_limit
+                || premium_ceded_rate == 0
+                || premium_ceded_rate > 10_000
+                || coverage_types.is_empty()
+                || duration_seconds == 0
+            {
+                return Err(InsuranceError::InvalidParameters);
+            }
 
             let now = self.env().block_timestamp();
             let agreement_id = self.reinsurance_count + 1;
@@ -1884,6 +1931,9 @@
             token_id: u64,
             price: u128,
         ) -> Result<(), InsuranceError> {
+            if token_id == 0 || price == 0 {
+                return Err(InsuranceError::InvalidParameters);
+            }
             let caller = self.env().caller();
             let mut token = self
                 .insurance_tokens
@@ -1988,6 +2038,16 @@
             if !self.role_manager.has_role(caller, Role::Oracle) {
                 return Err(InsuranceError::Unauthorized);
             }
+            if loss_frequency == 0
+                || average_loss_severity == 0
+                || expected_loss_ratio == 0
+                || expected_loss_ratio > 10_000
+                || confidence_level == 0
+                || confidence_level > 100
+                || data_points == 0
+            {
+                return Err(InsuranceError::InvalidParameters);
+            }
 
             let model_id = self.model_count + 1;
             self.model_count = model_id;
@@ -2027,6 +2087,13 @@
             self.pools
                 .get(&pool_id)
                 .ok_or(InsuranceError::PoolNotFound)?;
+            if min_property_value == 0
+                || max_property_value == 0
+                || min_property_value > max_property_value
+                || min_risk_score > 100
+            {
+                return Err(InsuranceError::InvalidParameters);
+            }
 
             let criteria = UnderwritingCriteria {
                 max_property_age_years,
@@ -2140,6 +2207,9 @@
         #[ink(message)]
         pub fn set_claim_cooldown(&mut self, period_seconds: u64) -> Result<(), InsuranceError> {
             self.ensure_role(Role::Admin)?;
+            if period_seconds == 0 {
+                return Err(InsuranceError::InvalidParameters);
+            }
             self.claim_cooldown_period = period_seconds;
             Ok(())
         }
@@ -2776,4 +2846,3 @@
             Ok(())
         }
     }
-


### PR DESCRIPTION

Implemented the boundary-check hardening and kept .codex ignored in git.

I added explicit non-zero / valid-range guards in the escrow, bridge, and insurance paths most exposed to numeric input:

Escrow now rejects zero property_id, zero/negative amount, past release_time_lock, zero escrow_id, and overfunding deposits in lib.rs (line 60) with shared helpers in validation.rs (line 27).
Bridge now rejects empty/zero chain config, zero signature thresholds, zero timeout/gas, zero token/request ids, zero metadata size/valuation, and zero optional timeout blocks in lib.rs (line 29) with helpers in validation.rs (line 63).
Insurance now validates zero or inverted numeric/range inputs across renewals, vesting config, risk assessments, premium calculation, policy creation, parametric event ids, evidence file size, reinsurance terms, token sale price, actuarial models, underwriting bounds, and claim cooldown updates in insurance_impl.rs (line 205).

closes #359 