### PR TITLE
Fix #407: Implement policy expiration validation

### DIFF
--- a/stellar-insured-contracts/contracts/claims/src/lib.rs
+++ b/stellar-insured-contracts/contracts/claims/src/lib.rs
@@ -54,16 +54,21 @@ impl ClaimsContract {
     pub fn submit_claim(env: Env, policy_id: u64, amount: i128) -> u64 {
         // #381: fetch policy and validate consistency before accepting claim
         let policy_contract: Address = env.storage().instance().get(&DataKey::PolicyContract).unwrap();
+        // #407: Centralized validation via Policy contract (includes expiration check)
+        let is_active: bool = env.invoke_contract(
+            &policy_contract,
+            &symbol_short!("is_active"),
+            (policy_id,).into(),
+        );
+        if !is_active {
+            panic!("Policy is not active or has expired");
+        }
+
         let policy: InsurancePolicy = env.invoke_contract(
             &policy_contract,
             &symbol_short!("get_pol"),
             (policy_id,).into(),
         );
-
-        // Consistency check: policy must be active
-        if policy.status != PolicyStatus::Active && policy.status != PolicyStatus::Renewed {
-            panic!("Policy is not active");
-        }
 
         // Consistency check: claim amount must not exceed coverage
         if amount <= 0 || amount > policy.coverage_amount {
@@ -73,13 +78,6 @@ impl ClaimsContract {
         // #409: O(1) duplicate claim check — reject if an active claim already exists for this policy
         if env.storage().persistent().has(&DataKey::PolicyActiveClaim(policy_id)) {
             panic!("Policy already has an active claim");
-        }
-
-        // #408: Verify policy hasn't expired
-        let now = env.ledger().timestamp();
-        let expiry_time = policy.start_time + (policy.duration_days as u64 * 86400);
-        if now > expiry_time {
-            panic!("Policy has expired");
         }
 
         let claimant = policy.holder.clone();

--- a/stellar-insured-contracts/contracts/policy/src/lib.rs
+++ b/stellar-insured-contracts/contracts/policy/src/lib.rs
@@ -98,12 +98,30 @@ impl PolicyContract {
         get_policy_inner(&env, policy_id)
     }
 
+    pub fn is_active(env: Env, policy_id: u64) -> bool {
+        let policy = get_policy_inner(&env, policy_id);
+        if policy.status != PolicyStatus::Active && policy.status != PolicyStatus::Renewed {
+            return false;
+        }
+
+        let now = env.ledger().timestamp();
+        let expiry = policy.start_time + (policy.duration_days as u64 * 86400);
+        now <= expiry
+    }
+
     pub fn renew_policy(env: Env, policy_id: u64, duration_days: u32) {
         let mut policy = get_policy_inner(&env, policy_id);
         policy.holder.require_auth();
 
         if policy.status != PolicyStatus::Active && policy.status != PolicyStatus::Renewed {
             panic!("Policy not active");
+        }
+
+        // #407: Ensure policy hasn't expired before renewal
+        let now = env.ledger().timestamp();
+        let expiry = policy.start_time + (policy.duration_days as u64 * 86400);
+        if now > expiry {
+            panic!("Policy has expired and cannot be renewed");
         }
 
         policy.duration_days += duration_days;
@@ -121,6 +139,13 @@ impl PolicyContract {
     pub fn cancel_policy(env: Env, policy_id: u64) {
         let mut policy = get_policy_inner(&env, policy_id);
         policy.holder.require_auth();
+
+        // #407: Ensure policy hasn't expired before cancellation
+        let now = env.ledger().timestamp();
+        let expiry = policy.start_time + (policy.duration_days as u64 * 86400);
+        if now > expiry {
+            panic!("Policy has already expired");
+        }
 
         policy.status = PolicyStatus::Cancelled;
         set_policy(&env, policy_id, &policy);


### PR DESCRIPTION
Closes #407

---

- Added centralized `is_active` validation to the Policy contract.
- Refactored the Claims contract to enforce expiration checks via cross-contract calls.
- Added guards to prevent renewals or cancellations of already expired policies.