### PR TITLE
refactor: remove forwardRef cycles via UserAuthFacade

### DIFF
--- a/meridian-api/src/auth/providers/auth.service.spec.ts
+++ b/meridian-api/src/auth/providers/auth.service.spec.ts
@@ -1,0 +1,29 @@
+// Mock all transitive src/-aliased paths that Jest can't resolve
+jest.mock('src/users/providers/user-auth.facade', () => ({ UserAuthFacade: class UserAuthFacade {} }), { virtual: true });
+jest.mock('src/users/providers/user.services', () => ({ UserService: class UserService {} }), { virtual: true });
+jest.mock('src/DTO/signin-dto', () => ({}), { virtual: true });
+jest.mock('./hashing', () => ({ HashingProvider: class HashingProvider {} }), { virtual: true });
+jest.mock('./token.provider', () => ({ GenerateTokenProvider: class GenerateTokenProvider {} }), { virtual: true });
+jest.mock('../dto/refresh-token-dto', () => ({}), { virtual: true });
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let signInProviders: { SignIn: jest.Mock };
+  let refreshTokenProvider: { refreshToken: jest.Mock };
+
+  beforeEach(() => {
+    signInProviders = { SignIn: jest.fn(async () => ({ accessToken: 'tok' })) };
+    refreshTokenProvider = { refreshToken: jest.fn(async () => ({ accessToken: 'new-tok' })) };
+
+    service = new AuthService(signInProviders as any, refreshTokenProvider as any);
+  });
+
+  it('SignIn delegates to signInProviders', async () => {
+    const dto = { email: 'a@b.com', password: 'pass' } as any;
+    const result = await service.SignIn(dto);
+    expect(signInProviders.SignIn).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ accessToken: 'tok' });
+  });
+});

--- a/meridian-api/src/auth/providers/auth.service.ts
+++ b/meridian-api/src/auth/providers/auth.service.ts
@@ -1,6 +1,5 @@
-import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { SignInDto } from 'src/DTO/signin-dto';
-import { UserService } from 'src/users/providers/user.services';
 import { SignInProviders } from './sign-in.providers';
 import { RefreshTokenDto } from '../dto/refresh-token-dto';
 import { RefreshTokenProvider } from './refreshToken.provider';
@@ -8,9 +7,6 @@ import { RefreshTokenProvider } from './refreshToken.provider';
 @Injectable()
 export class AuthService {
     constructor(
-        @Inject(forwardRef(() => UserService)) 
-        private readonly userService: UserService,
-
         //intra dependency injection of sigin Providers
         private readonly signInProviders:SignInProviders,
 
@@ -20,11 +16,6 @@ export class AuthService {
     public async SignIn(signInDto:SignInDto) {
         // find user in database by email
        return await this.signInProviders.SignIn(signInDto)
-
-        // throw an error if user is not found
-        // compare password to the hashed password
-        // send confirmation message 
-
     }
 
     public async RefreshToken (refreshTokendto:RefreshTokenDto) {

--- a/meridian-api/src/auth/providers/sign-in.providers.ts
+++ b/meridian-api/src/auth/providers/sign-in.providers.ts
@@ -1,8 +1,7 @@
-import { forwardRef, Inject, Injectable, RequestTimeoutException, UnauthorizedException } from '@nestjs/common';
+import { Injectable, RequestTimeoutException, UnauthorizedException } from '@nestjs/common';
 import { SignInDto } from 'src/DTO/signin-dto';
-import { UserService } from 'src/users/providers/user.services';
+import { UserAuthFacade } from 'src/users/providers/user-auth.facade';
 import { HashingProvider } from './hashing';
-import { access, truncate } from 'fs';
 import { JwtService } from '@nestjs/jwt';
 import jwtConfig from '../config/jwt.config';
 import { ConfigType } from '@nestjs/config';
@@ -11,34 +10,27 @@ import { GenerateTokenProvider } from './token.provider';
 @Injectable()
 export class SignInProviders {
     constructor (
-        //circular dependency injection
-        @Inject(forwardRef(() => UserService))
-        private readonly userService:UserService,
+        private readonly userAuthFacade: UserAuthFacade,
 
         //intra dependcy injection of hash provider
         private readonly hashingProvider:HashingProvider,
 
         // injecting generatetokenprovider
         private readonly generateTokenProvider:GenerateTokenProvider
-
-
     ) {}
 
     public async SignIn (signInDto:SignInDto) {
         // find user by email
-        // throw an error
-        let user =  await this.userService.GetOneByEmail(signInDto.email)
+        let user = await this.userAuthFacade.findUserByEmail(signInDto.email)
         
         //compare the password to the hashed password
         let isEqual:boolean = false;
         try {
             isEqual = await this.hashingProvider.comparePassword(signInDto.password, user.password)
-
         } catch (error) {
             throw new RequestTimeoutException(error, {
                 description:'error connecting to database'
             })
-
         }
 
         //send a confirmation
@@ -46,12 +38,7 @@ export class SignInProviders {
             throw new UnauthorizedException('password/email is wrong')
         }
         
-       
         const token = await this.generateTokenProvider.generateTokens(user)
         return [token ,user]
-    //accesstoken store into local storage,
-    //refreshtoken stored in DB
-
     }    
-
 }

--- a/meridian-api/src/users/providers/user-auth.facade.spec.ts
+++ b/meridian-api/src/users/providers/user-auth.facade.spec.ts
@@ -1,0 +1,24 @@
+// Mock entities that import src/-aliased paths not available in Jest
+jest.mock('../user.entity', () => ({ User: class User {} }), { virtual: true });
+jest.mock('src/post/post.entity', () => ({ Post: class Post {} }), { virtual: true });
+jest.mock('src/tweets/dto/tweet.entity', () => ({ Tweet: class Tweet {} }), { virtual: true });
+
+import { UserAuthFacade } from './user-auth.facade';
+
+describe('UserAuthFacade', () => {
+  let facade: UserAuthFacade;
+  let findOneByEmail: { findOneByEmail: jest.Mock };
+
+  const mockUser = { id: 1, email: 'a@b.com' };
+
+  beforeEach(() => {
+    findOneByEmail = { findOneByEmail: jest.fn(async () => mockUser) };
+    facade = new UserAuthFacade(findOneByEmail as any);
+  });
+
+  it('findUserByEmail delegates to FindOneByEmail provider', async () => {
+    const result = await facade.findUserByEmail('a@b.com');
+    expect(findOneByEmail.findOneByEmail).toHaveBeenCalledWith('a@b.com');
+    expect(result).toEqual(mockUser);
+  });
+});

--- a/meridian-api/src/users/providers/user-auth.facade.ts
+++ b/meridian-api/src/users/providers/user-auth.facade.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { FindOneByEmail } from './find-one-by-email';
+import { User } from '../user.entity';
+
+@Injectable()
+export class UserAuthFacade {
+  constructor(private readonly findOneByEmail: FindOneByEmail) {}
+
+  public async findUserByEmail(email: string): Promise<User> {
+    return this.findOneByEmail.findOneByEmail(email);
+  }
+}

--- a/meridian-api/src/users/providers/user.service.spec.ts
+++ b/meridian-api/src/users/providers/user.service.spec.ts
@@ -1,0 +1,87 @@
+// Mock entities that import src/-aliased paths not available in Jest
+jest.mock('../user.entity', () => ({ User: class User {} }), { virtual: true });
+jest.mock('src/post/post.entity', () => ({ Post: class Post {} }), { virtual: true });
+jest.mock('src/tweets/dto/tweet.entity', () => ({ Tweet: class Tweet {} }), { virtual: true });
+jest.mock('src/auth/providers/hashing', () => ({ HashingProvider: class HashingProvider {} }), { virtual: true });
+jest.mock('src/mail/providers/mail.provider', () => ({ MailProvider: class MailProvider {} }), { virtual: true });
+jest.mock('src/commom/userAlreadyExistException', () => ({ UserAlreadyExistException: class UserAlreadyExistException {} }), { virtual: true });
+jest.mock('src/DTO/create-user.dto', () => ({}), { virtual: true });
+jest.mock('src/DTO/postparamdto', () => ({}), { virtual: true });
+jest.mock('src/DTO/patch-user.dto', () => ({}), { virtual: true });
+
+import { HttpException } from '@nestjs/common';
+import { UserService } from './user.services';
+
+describe('UserService', () => {
+  let service: UserService;
+  let usersRepository: { find: jest.Mock; findOneBy: jest.Mock; save: jest.Mock };
+  let createuserprovider: { createUsers: jest.Mock };
+  let findOneByemail: { findOneByEmail: jest.Mock };
+  let createUserWithBooks: { createUserwithBook: jest.Mock; getAllUserWithBook: jest.Mock };
+  let createManyUserService: { manyUsers: jest.Mock };
+
+  const mockUser = { id: 1, firstName: 'Jane', lastName: 'Doe', email: 'jane@example.com', password: 'hashed' };
+
+  beforeEach(() => {
+    usersRepository = {
+      find: jest.fn(async () => [mockUser]),
+      findOneBy: jest.fn(async () => mockUser),
+      save: jest.fn(async (u) => u),
+    };
+    createuserprovider = { createUsers: jest.fn(async () => [mockUser]) };
+    findOneByemail = { findOneByEmail: jest.fn(async () => mockUser) };
+    createUserWithBooks = {
+      createUserwithBook: jest.fn(async () => mockUser),
+      getAllUserWithBook: jest.fn(async () => [mockUser]),
+    };
+    createManyUserService = { manyUsers: jest.fn(async () => [mockUser]) };
+
+    service = new UserService(
+      usersRepository as any,
+      createuserprovider as any,
+      findOneByemail as any,
+      createUserWithBooks as any,
+      createManyUserService as any,
+    );
+  });
+
+  it('findAll returns users from repository', async () => {
+    const result = await service.findAll({} as any, 10, 1);
+    expect(result).toEqual([mockUser]);
+    expect(usersRepository.find).toHaveBeenCalled();
+  });
+
+  it('createUsers delegates to createuserprovider', async () => {
+    const dto = { email: 'jane@example.com', password: 'pass', firstName: 'Jane', lastName: 'Doe' } as any;
+    const result = await service.createUsers(dto);
+    expect(createuserprovider.createUsers).toHaveBeenCalledWith(dto);
+    expect(result).toEqual([mockUser]);
+  });
+
+  it('GetOneByEmail delegates to findOneByemail', async () => {
+    const result = await service.GetOneByEmail('jane@example.com');
+    expect(findOneByemail.findOneByEmail).toHaveBeenCalledWith('jane@example.com');
+    expect(result).toEqual(mockUser);
+  });
+
+  it('findOneId returns user when found', async () => {
+    const result = await service.findOneId(1);
+    expect(usersRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+    expect(result).toEqual(mockUser);
+  });
+
+  it('findOneId throws NOT_FOUND when user is missing', async () => {
+    usersRepository.findOneBy.mockResolvedValue(null);
+    await expect(service.findOneId(99)).rejects.toThrow(HttpException);
+  });
+
+  it('editUser saves updated user', async () => {
+    const dto = { id: 1, firstName: 'Updated' } as any;
+    await service.editUser(dto);
+    expect(usersRepository.save).toHaveBeenCalled();
+  });
+
+  it('deleteUser throws HttpException', async () => {
+    await expect(service.deleteUser()).rejects.toThrow(HttpException);
+  });
+});

--- a/meridian-api/src/users/providers/user.services.ts
+++ b/meridian-api/src/users/providers/user.services.ts
@@ -1,20 +1,17 @@
-import { Injectable,Inject,RequestTimeoutException,BadRequestException, HttpException, HttpStatus, forwardRef } from "@nestjs/common";
+import { Injectable, HttpException, HttpStatus } from "@nestjs/common";
 // import { GetuserParamDto } from "src/DTO/userparamdto";
 import { InjectRepository } from "@nestjs/typeorm";
-import { DataSource, Repository } from "typeorm";
+import { Repository } from "typeorm";
 import { User } from "../user.entity";
 import { CreateUserDto } from "src/DTO/create-user.dto";
 import { GetPostsParamDto } from "src/DTO/postparamdto"; 
 import { EditUserDto } from "src/DTO/patch-user.dto";
-import { AuthService } from "src/auth/providers/auth.service";
-import { HashingProvider } from "src/auth/providers/hashing";
 import { CreateUserProvider } from "./create-user.provider";
 import { FindOneByEmail } from "./find-one-by-email";
 // import { Pagination } from "src/commom/pagination/Provider/pagination";
 import { CreateManyUser } from "./createManyUser.Provider";
 import { CreateManyUsersDto } from "../dtos/createManyUserdto";
 import { CreateUserBookProvider } from "./createUserWithBook";
-import { table } from "console";
 
 @Injectable()
 export class UserService {
@@ -28,17 +25,10 @@ export class UserService {
       //dependecy injection for findoneByemail Provider
       private readonly findOneByemail:FindOneByEmail,
 
-      //circular dependecy injection for Authservice
-      @Inject(forwardRef(() => AuthService))
-          private readonly authService: AuthService,
-
-    private readonly createUserWithBooks:CreateUserBookProvider,
-
+      private readonly createUserWithBooks:CreateUserBookProvider,
 
       // depedency injection of createManyUsers
       private readonly createManyUserService:CreateManyUser,
-
-
   ) {}
     // repository pattern that help commiunicate with the Database 
     // just by doing this we have injected a repository pattern

--- a/meridian-api/src/users/users.module.ts
+++ b/meridian-api/src/users/users.module.ts
@@ -10,6 +10,7 @@ import { CreateManyUser } from './providers/createManyUser.Provider';
 import { CreateUserBookProvider } from './providers/createUserWithBook';
 import { Tweet } from 'src/tweets/dto/tweet.entity';
 import { TweetModule } from 'src/tweets/dto/tweet.module';
+import { UserAuthFacade } from './providers/user-auth.facade';
 
 
 @Module({
@@ -23,8 +24,9 @@ import { TweetModule } from 'src/tweets/dto/tweet.module';
       FindOneByEmail,
       CreateManyUser,
       CreateUserBookProvider,
+      UserAuthFacade,
     
   ],
-  exports: [TypeOrmModule, UserService],
+  exports: [TypeOrmModule, UserService, UserAuthFacade],
 })
 export class UsersModule {}


### PR DESCRIPTION
 Closes #422 
- Create UserAuthFacade in users/providers to wrap FindOneByEmail
- Remove AuthService injection from UserService (unused)
- Remove UserService injection from AuthService (unused)
- Replace forwardRef UserService injection in SignInProviders with UserAuthFacade
- Export UserAuthFacade from UsersModule so AuthModule can consume it
- Add unit tests for UserService, AuthService, and UserAuthFacade