### PR TITLE
feat(api): apply Helmet.js security headers (closes #448)

### DIFF
--- a/meridian-api/package-lock.json
+++ b/meridian-api/package-lock.json
@@ -24,6 +24,7 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "helmet": "^8.2.0",
         "mysql2": "^3.11.5",
         "pg": "^8.13.1",
         "prom-client": "^15.1.3",
@@ -7170,6 +7171,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14119,7 +14132,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/meridian-api/package.json
+++ b/meridian-api/package.json
@@ -35,6 +35,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "helmet": "^8.2.0",
     "mysql2": "^3.11.5",
     "pg": "^8.13.1",
     "prom-client": "^15.1.3",

--- a/meridian-api/src/main.ts
+++ b/meridian-api/src/main.ts
@@ -2,10 +2,17 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import helmet from 'helmet';
 import { DataResponseInterceptor } from './commom/interceptor/data-response/data-response.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Apply baseline security headers (Closes #448).
+  // CSP is disabled to avoid breaking the @nestjs/swagger UI at /api,
+  // which requires inline scripts/styles. Other helmet defaults (HSTS,
+  // X-Frame-Options, X-Content-Type-Options, Referrer-Policy, etc.) remain on.
+  app.use(helmet({ contentSecurityPolicy: false }));
 
   // Set global validation pipes
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary

Adds the [helmet](https://helmetjs.github.io/) middleware to the
NestJS bootstrap so the `meridian-api` sets a baseline of security
response headers on every request.

Closes #448.

## What changed

### `meridian-api/package.json`
- Adds `helmet` (`^8.2.0`) as a runtime dependency.

### `meridian-api/src/main.ts`
- Imports `helmet` alongside the existing bootstrap imports.
- Applies the middleware immediately after `NestFactory.create(AppModule)`
  and before any other middleware, pipes, or Swagger setup:

  ```ts
  // Apply baseline security headers (Closes #448).
  // CSP is disabled to avoid breaking the @nestjs/swagger UI at /api,
  // which requires inline scripts/styles. Other helmet defaults (HSTS,
  // X-Frame-Options, X-Content-Type-Options, Referrer-Policy, etc.) remain on.
  app.use(helmet({ contentSecurityPolicy: false }));
  ```

## Why

Without helmet, the API was sending responses with only the defaults
that Express provides, which is well below the baseline most security
scanners and front-ends expect. This puts HSTS, `X-Frame-Options`,
`X-Content-Type-Options`, `Referrer-Policy`, `Cross-Origin-*` headers,
and others on every response with a single dependency and a single line
of integration code.

## Notes / limitations

- **Content-Security-Policy is intentionally disabled.** The
  `@nestjs/swagger` UI at `/api` injects inline scripts and inline
  styles to render correctly; the helmet default CSP would block them.
  A follow-up should configure a Swagger-compatible CSP (or scope a
  strict CSP to non-docs routes). Tracked separately.
- Placed *before* `useGlobalPipes` so the headers attach even to
  request-validation failures.
- No behavior change beyond security headers; no API surface change.

## Test plan

- [x] `npm run build` in `meridian-api/` -> exits 0 (no type errors).
- [x] `npx jest --passWithNoTests` in `meridian-api/` -> all 16 existing tests pass.
- [ ] Manual: `curl -I http://localhost:3000/health` (or any route) should now include:
      - `Strict-Transport-Security`
      - `X-Frame-Options: SAMEORIGIN`
      - `X-Content-Type-Options: nosniff`
      - `Referrer-Policy: no-referrer`
- [ ] Manual: `GET /api` (Swagger UI) still renders correctly.

## Linked issues

- Closes #448
