### PR TITLE
fix(web): implement persistent theme system with light/dark toggle (#437)

### DIFF
--- a/meridian-web/app/globals.css
+++ b/meridian-web/app/globals.css
@@ -1,27 +1,33 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/*
+ * `next-themes` applies `class="light"` or `class="dark"` to <html>.
+ * We mirror that into Tailwind via @custom-variant dark.
+ * Default (:root) = light; .dark <html> overrides with the dark palette.
+ */
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.12 0 0);
-  --foreground: oklch(0.98 0 0);
-  --card: oklch(0.16 0 0);
-  --card-foreground: oklch(0.98 0 0);
-  --popover: oklch(0.16 0 0);
-  --popover-foreground: oklch(0.98 0 0);
+  /* --- LIGHT MODE (default) --- */
+  --background: oklch(0.995 0 0);
+  --foreground: oklch(0.18 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.18 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0 0);
   --primary: oklch(0.74 0.181 73.75);
-  --primary-foreground: oklch(0.12 0 0);
-  --secondary: oklch(0.25 0 0);
-  --secondary-foreground: oklch(0.98 0 0);
-  --muted: oklch(0.35 0 0);
-  --muted-foreground: oklch(0.65 0 0);
-  --accent: oklch(0.74 0.181 73.75);
-  --accent-foreground: oklch(0.12 0 0);
+  --primary-foreground: oklch(0.18 0 0);
+  --secondary: oklch(0.96 0.005 247);
+  --secondary-foreground: oklch(0.18 0 0);
+  --muted: oklch(0.96 0.005 247);
+  --muted-foreground: oklch(0.5 0.01 247);
+  --accent: oklch(0.94 0.04 80);
+  --accent-foreground: oklch(0.18 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.25 0 0);
-  --input: oklch(0.25 0 0);
+  --border: oklch(0.92 0.005 247);
+  --input: oklch(0.92 0.005 247);
   --ring: oklch(0.74 0.181 73.75);
   --chart-1: oklch(0.74 0.181 73.75);
   --chart-2: oklch(0.62 0.165 84.429);
@@ -29,17 +35,18 @@
   --chart-4: oklch(0.73 0.17 80);
   --chart-5: oklch(0.68 0.155 76);
   --radius: 0.625rem;
-  --sidebar: oklch(0.12 0 0);
-  --sidebar-foreground: oklch(0.98 0 0);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.18 0 0);
   --sidebar-primary: oklch(0.74 0.181 73.75);
-  --sidebar-primary-foreground: oklch(0.12 0 0);
-  --sidebar-accent: oklch(0.35 0 0);
-  --sidebar-accent-foreground: oklch(0.98 0 0);
-  --sidebar-border: oklch(0.25 0 0);
+  --sidebar-primary-foreground: oklch(0.18 0 0);
+  --sidebar-accent: oklch(0.96 0.005 247);
+  --sidebar-accent-foreground: oklch(0.18 0 0);
+  --sidebar-border: oklch(0.92 0.005 247);
   --sidebar-ring: oklch(0.74 0.181 73.75);
 }
 
 .dark {
+  /* --- DARK MODE (overrides) --- */
   --background: oklch(0.12 0 0);
   --foreground: oklch(0.98 0 0);
   --card: oklch(0.16 0 0);
@@ -50,14 +57,14 @@
   --primary-foreground: oklch(0.12 0 0);
   --secondary: oklch(0.25 0 0);
   --secondary-foreground: oklch(0.98 0 0);
-  --muted: oklch(0.35 0 0);
-  --muted-foreground: oklch(0.65 0 0);
+  --muted: oklch(0.25 0 0);
+  --muted-foreground: oklch(0.7 0.005 247);
   --accent: oklch(0.74 0.181 73.75);
   --accent-foreground: oklch(0.12 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.25 0 0);
-  --input: oklch(0.25 0 0);
+  --border: oklch(0.27 0 0);
+  --input: oklch(0.27 0 0);
   --ring: oklch(0.74 0.181 73.75);
   --chart-1: oklch(0.74 0.181 73.75);
   --chart-2: oklch(0.62 0.165 84.429);
@@ -68,9 +75,9 @@
   --sidebar-foreground: oklch(0.98 0 0);
   --sidebar-primary: oklch(0.74 0.181 73.75);
   --sidebar-primary-foreground: oklch(0.12 0 0);
-  --sidebar-accent: oklch(0.35 0 0);
+  --sidebar-accent: oklch(0.25 0 0);
   --sidebar-accent-foreground: oklch(0.98 0 0);
-  --sidebar-border: oklch(0.25 0 0);
+  --sidebar-border: oklch(0.27 0 0);
   --sidebar-ring: oklch(0.74 0.181 73.75);
 }
 

--- a/meridian-web/app/layout.tsx
+++ b/meridian-web/app/layout.tsx
@@ -1,7 +1,8 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
+import { ThemeProvider } from '@/components/theme-provider'
 
 const _geist = Geist({ subsets: ["latin"] });
 const _geistMono = Geist_Mono({ subsets: ["latin"] });
@@ -29,15 +30,37 @@ export const metadata: Metadata = {
   },
 }
 
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#0a0a0a' },
+  ],
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className="bg-background">
+    // suppressHydrationWarning is required by next-themes to avoid a
+    // hydration mismatch when it writes the resolved theme class on
+    // the <html> element during the initial client render.
+    <html
+      lang="en"
+      className="bg-background"
+      suppressHydrationWarning
+    >
       <body className="font-sans antialiased">
-        {children}
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          storageKey="meridian-theme"
+          themes={['light', 'dark', 'system']}
+        >
+          {children}
+        </ThemeProvider>
         {process.env.NODE_ENV === 'production' && <Analytics />}
       </body>
     </html>

--- a/meridian-web/app/not-found.tsx
+++ b/meridian-web/app/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from "next/next-links";
+import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 
 export default function NotFoundState() {

--- a/meridian-web/components/layout/Header.tsx
+++ b/meridian-web/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
 import { useState } from 'react';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false);
@@ -34,7 +35,8 @@ export function Header() {
           </nav>
 
           {/* CTA - Desktop */}
-          <div className="hidden md:flex items-center gap-4">
+          <div className="hidden md:flex items-center gap-3">
+            <ThemeToggle />
             <button className="px-6 py-2 text-sm font-medium text-foreground hover:text-primary transition-colors">
               Sign In
             </button>
@@ -83,6 +85,12 @@ export function Header() {
             >
               Features
             </Link>
+            <div className="flex items-center justify-between gap-2 px-4 pt-2">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                Theme
+              </span>
+              <ThemeToggle />
+            </div>
             <button className="w-full px-4 py-2 text-sm font-medium rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-colors">
               Get Started
             </button>

--- a/meridian-web/components/theme-toggle.tsx
+++ b/meridian-web/components/theme-toggle.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import * as React from 'react';
+import { useTheme } from 'next-themes';
+import { Monitor, Moon, Sun } from 'lucide-react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+type Theme = 'light' | 'dark' | 'system';
+
+/**
+ * ThemeToggle
+ * Dropdown that lets the user pick Light, Dark, or System (auto).
+ * Persistence is handled by `next-themes` via the configured
+ * `storageKey` on the ThemeProvider (see app/layout.tsx).
+ */
+export function ThemeToggle({
+  className,
+  align = 'end',
+}: {
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+}): React.ReactElement {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  // Avoid hydration mismatch: render a stable placeholder until mount.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  // next-themes returns `theme` as `string | undefined` before mount.
+  // Narrow it to our explicit Theme union, falling back to 'system'.
+  const current: Theme =
+    theme === 'light' || theme === 'dark' || theme === 'system'
+      ? theme
+      : 'system';
+
+  const effectiveForIcon: 'light' | 'dark' =
+    current === 'system' ? (resolvedTheme as 'light' | 'dark') || 'light' : current;
+
+  const TriggerIcon =
+    !mounted
+      ? Sun
+      : effectiveForIcon === 'dark'
+      ? Moon
+      : Sun;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Toggle theme"
+        className={cn(
+          'inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background/60 text-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+          className,
+        )}
+      >
+        <TriggerIcon className="h-[1.1rem] w-[1.1rem]" aria-hidden="true" />
+        <span className="sr-only">Toggle theme</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="min-w-[10rem]">
+        <DropdownMenuLabel className="px-2 text-xs font-semibold text-muted-foreground">
+          Appearance
+        </DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={current}
+          onValueChange={(value) => setTheme(value as Theme)}
+        >
+          <DropdownMenuRadioItem value="light" className="cursor-pointer">
+            <Sun className="mr-2 h-4 w-4" aria-hidden="true" />
+            Light
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="dark" className="cursor-pointer">
+            <Moon className="mr-2 h-4 w-4" aria-hidden="true" />
+            Dark
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="system" className="cursor-pointer">
+            <Monitor className="mr-2 h-4 w-4" aria-hidden="true" />
+            System
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          disabled
+          className="cursor-default px-2 text-[11px] text-muted-foreground"
+        >
+          {mounted
+            ? `Active: ${
+                effectiveForIcon === 'dark' ? 'Dark' : 'Light'
+              }${current === 'system' ? ' · auto' : ''}`
+            : 'Loading theme…'}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default ThemeToggle;


### PR DESCRIPTION
## Summary

Resolves #437 by wiring the previously unused `next-themes` dependency into the application, exposing a Light / Dark / System toggle, and differentiating the light and dark CSS palettes so the toggle is visually effective (the prior `:root` and `.dark` blocks were identical).

## Changes

- `meridian-web/app/layout.tsx` — wrap children in `ThemeProvider` (`attribute="class"`, `defaultTheme="system"`, custom `storageKey="meridian-theme"`); add `suppressHydrationWarning` to `<html>` and a `themeColor` viewport entry.
- `meridian-web/components/theme-toggle.tsx` — new client component using `useTheme()` + Radix `dropdown-menu` (Light / Dark / System)
- `meridian-web/components/layout/Header.tsx` — mount `<ThemeToggle />` in both desktop and mobile navigation.
- `meridian-web/app/globals.css` — define a real light palette in `:root` and consolidate the dark palette under `.dark` (Tailwind v4 `@custom-variant dark (&:is(.dark *))`).

**Drive-by (1-char typo)**

- `meridian-web/app/not-found.tsx` — fix invalid `next/next-links` import → `next/link` so `pnpm build` succeeds.

## Testing

- `pnpm exec tsc --noEmit` — clean.
- `pnpm run build` — clean; static routes `/`, `/_not-found` regenerated.
- `pnpm run lint` — the project's `lint` script runs `eslint .`, but `eslint` is not currently declared in `devDependencies`; this is a pre-existing repo-wide setup issue and not introduced by this PR.

Closes #437