### PR TITLE
feat(api): soft-delete for Post and User with restore endpoint (#427)

### DIFF
--- a/meridian-api/package-lock.json
+++ b/meridian-api/package-lock.json
@@ -6833,7 +6833,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14133,7 +14132,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/meridian-api/src/post/post.controller.ts
+++ b/meridian-api/src/post/post.controller.ts
@@ -43,10 +43,21 @@ export class PostController {
   }
 
   @Delete()
-  @ApiOperation({ summary: 'Delete a post' })
-  @ApiResponse({ status: 200, description: 'Post deleted successfully' })
+  @ApiOperation({ summary: 'Soft-delete a post (issue #427)' })
+  @ApiResponse({ status: 200, description: 'Post soft-deleted successfully' })
   public deleteOne(@Query('id', ParseIntPipe) id: number) {
     return this.postService.deleteOne(id);
+  }
+
+  @Post('/:id/restore')
+  @ApiOperation({ summary: 'Restore a soft-deleted post by ID' })
+  @ApiResponse({ status: 200, description: 'Post restored successfully' })
+  @ApiResponse({
+    status: 404,
+    description: 'Post not found or not soft-deleted',
+  })
+  public restorePost(@Param('id', ParseIntPipe) id: number) {
+    return this.postService.restorePost(id);
   }
 
   @Patch()

--- a/meridian-api/src/post/post.entity.ts
+++ b/meridian-api/src/post/post.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   ManyToMany,
   JoinTable,
+  DeleteDateColumn,
 } from 'typeorm';
 import { postType } from './Enums/post-type.enum';
 import { PostStatus } from './Enums/post-status.enum';
@@ -63,6 +64,10 @@ export class Post {
   @ManyToMany(() => Tag, (tags) => tags.post)
   @JoinTable()
   tags: Tag[];
+
+  // Soft-delete marker (issue #427): when set the row is hidden from queries
+  @DeleteDateColumn()
+  deletedAt?: Date;
 
   // the joincolumn when used if you check your pg a new column is created shwoing Id of metaoption entity
   // id of metaooptons is joined with Post

--- a/meridian-api/src/post/provider/post.service.ts
+++ b/meridian-api/src/post/provider/post.service.ts
@@ -1,4 +1,4 @@
-import { Body, Injectable } from '@nestjs/common';
+import { Body, HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { GetPostsParamDto } from '../dto/post-param.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from '../post.entity';
@@ -36,11 +36,35 @@ export class PostsService {
     }
   }
 
+  /**
+   * Soft-deletes a post (issue #427).
+   * TypeORM automatically excludes rows with a non-null `deletedAt` from
+   * subsequent `find*` calls. Use `restorePost` to undo this operation.
+   */
   public async deleteOne(id: number) {
-    //find the post you want to delete, find the metaoption of the post you want to delete
-    await this.postRepository.delete(id);
+    await this.postRepository.softDelete(id);
 
     return { deleted: true, id };
+  }
+
+  /**
+   * Restores a soft-deleted post, clearing its `deletedAt` value so it
+   * reappears in regular queries.
+   */
+  public async restorePost(id: number) {
+    const result = await this.postRepository.restore(id);
+
+    if (!result.affected) {
+      throw new HttpException(
+        {
+          status: HttpStatus.NOT_FOUND,
+          error: `Post with id ${id} was not found or is not soft-deleted`,
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return { restored: true, id };
   }
 
   public async createPost(createpostDto: CreatePostDto) {

--- a/meridian-api/src/users/providers/user.services.ts
+++ b/meridian-api/src/users/providers/user.services.ts
@@ -49,14 +49,44 @@ export class UserService {
     return await this.findOneByemail.findOneByEmail(email);
   }
 
-  public async deleteUser() {
-    throw new HttpException(
-      {
-        status: HttpStatus.TEMPORARY_REDIRECT,
-        error: 'User has been removed',
-      },
-      HttpStatus.TEMPORARY_REDIRECT,
-    );
+  /**
+   * Soft-deletes a user (issue #427). TypeORM will hide the row from
+   * subsequent `find*` queries; use `restoreUser` to undo.
+   */
+  public async deleteUser(id: number) {
+    const user = await this.usersRepository.findOneBy({ id });
+    if (!user) {
+      throw new HttpException(
+        {
+          status: HttpStatus.NOT_FOUND,
+          error: `User with id ${id} not found`,
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.usersRepository.softDelete(id);
+
+    return { deleted: true, id };
+  }
+
+  /**
+   * Restores a soft-deleted user, clearing its `deletedAt` value.
+   */
+  public async restoreUser(id: number) {
+    const result = await this.usersRepository.restore(id);
+
+    if (!result.affected) {
+      throw new HttpException(
+        {
+          status: HttpStatus.NOT_FOUND,
+          error: `User with id ${id} was not found or is not soft-deleted`,
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return { restored: true, id };
   }
 
   //finding users by id and userservice was exported in postmodule i.e export:[typeorm,userservice]

--- a/meridian-api/src/users/user.entity.ts
+++ b/meridian-api/src/users/user.entity.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   OneToOne,
   JoinColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 
 @Entity()
@@ -34,6 +35,11 @@ export class User {
 
   @OneToMany(() => Tweet, (tweet) => tweet.user)
   tweet: Tweet[];
+
+  // Soft-delete marker (issue #427): when set the row is hidden from queries
+  // but can be restored via POST /users/:id/restore
+  @DeleteDateColumn()
+  deletedAt?: Date;
 
   // @Column({ default: true })
   // isActive: boolean;

--- a/meridian-api/src/users/users.controller.ts
+++ b/meridian-api/src/users/users.controller.ts
@@ -100,11 +100,23 @@ export class UsersController {
     return this.userService.createMany(createManyUserDto);
   }
 
-  @Delete()
-  @ApiOperation({ summary: 'Delete users' })
-  @ApiResponse({ status: 200, description: 'Users deleted successfully' })
-  public deleteUsers() {
-    return this.userService.deleteUser;
+  @Delete('/:id')
+  @ApiOperation({ summary: 'Soft-delete a user by ID (issue #427)' })
+  @ApiResponse({ status: 200, description: 'User soft-deleted successfully' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  public deleteUsers(@Param('id', ParseIntPipe) id: number) {
+    return this.userService.deleteUser(id);
+  }
+
+  @Post('/:id/restore')
+  @ApiOperation({ summary: 'Restore a soft-deleted user by ID' })
+  @ApiResponse({ status: 200, description: 'User restored successfully' })
+  @ApiResponse({
+    status: 404,
+    description: 'User not found or not soft-deleted',
+  })
+  public restoreUser(@Param('id', ParseIntPipe) id: number) {
+    return this.userService.restoreUser(id);
   }
 
   @Patch()


### PR DESCRIPTION
Implements soft-delete (issue #427) for Post and User entities, plus restore endpoints.

## Summary
- Add `@DeleteDateColumn() deletedAt?` to Post and User entities. TypeORM hides soft-deleted rows from `find*` queries.
- `PostsService.deleteOne` switches to `repository.softDelete`; adds `restorePost(id)` returning `{ restored: true, id }` or 404.
- `UserService.deleteUser` now takes an `id` and uses `repository.softDelete`; adds `restoreUser(id)`.
- Routes: `DELETE /users/:id`, `POST /posts/:id/restore`, `POST /users/:id/restore`.
- Dropped the unused `@nestjs/schedule` dependency that was added earlier on this branch.

## Behavior change
`UserService.deleteUser` previously returned 307 TEMPORARY_REDIRECT; the controller was binding the bare method reference and never invoked it (a pre-existing bug fixed here). It now soft-deletes and returns `{ deleted: true, id }` (200) or 404.

Closes #427