### PR TITLE
fix(api): harden DataResponseInterceptor for non-array responses (closes #426)

### DIFF
--- a/meridian-api/src/common/interceptors/data-response.interceptor.spec.ts
+++ b/meridian-api/src/common/interceptors/data-response.interceptor.spec.ts
@@ -1,0 +1,239 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { lastValueFrom, of } from 'rxjs';
+import {
+  API_VERSION,
+  DataResponseInterceptor,
+} from './data-response.interceptor';
+
+/**
+ * Builds a minimal ExecutionContext stub. DataResponseInterceptor never
+ * touches the context, so we only need the surface NestJS expects to
+ * exist when the interceptor is invoked.
+ */
+const buildContext = (): ExecutionContext =>
+  ({
+    switchToHttp: () => ({}),
+  }) as unknown as ExecutionContext;
+
+/**
+ * Drives the interceptor end-to-end with `next.handle()` replaced by
+ * an RxJS stream that emits `value`. Returns the resolved envelope
+ * (the final onNext value passed to the HTTP socket).
+ */
+const runHandler = async <T>(value: T) => {
+  const interceptor = new DataResponseInterceptor<T>();
+  const handler: CallHandler<T> = { handle: () => of(value) };
+  const result$ = interceptor.intercept(buildContext(), handler);
+  return lastValueFrom(result$);
+};
+
+describe('DataResponseInterceptor', () => {
+  describe('constants', () => {
+    it('exports the API version', () => {
+      expect(API_VERSION).toBe('0.0.1');
+    });
+  });
+
+  describe('array responses', () => {
+    it('wraps an empty array with result: 0', async () => {
+      expect(await runHandler([])).toEqual({
+        apiversion: API_VERSION,
+        result: 0,
+        data: [],
+      });
+    });
+
+    it('wraps a single-item array with result: 1', async () => {
+      expect(await runHandler([{ id: 1 }])).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: [{ id: 1 }],
+      });
+    });
+
+    it('wraps a multi-item array with result equal to its length', async () => {
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      expect(await runHandler(items)).toEqual({
+        apiversion: API_VERSION,
+        result: 4,
+        data: items,
+      });
+    });
+
+    it('does not mutate the original array', async () => {
+      const items = [{ id: 1 }, { id: 2 }];
+      await runHandler(items);
+      expect(items).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+  });
+
+  describe('single object responses', () => {
+    it('wraps a plain POJO with result: 1 and preserves the object', async () => {
+      const obj = { id: 1, email: 'a@b.com', firstName: 'Jane' };
+      expect(await runHandler(obj)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: obj,
+      });
+    });
+
+    it('wraps a paginated wrapper object with result: 1 (no double-wrap)', async () => {
+      const paginated = {
+        data: [{ id: 1 }, { id: 2 }],
+        meta: { total: 2, page: 1, limit: 10 },
+      };
+      expect(await runHandler(paginated)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: paginated,
+      });
+    });
+
+    it('does NOT treat a plain object with a numeric length property as an array', async () => {
+      // Guard against accidental `.length`-based detection that would
+      // mis-classify e.g. `{ id: 1, length: 7 }` as a 7-item array.
+      const objLike = { id: 1, length: 7 };
+      expect(await runHandler(objLike)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: objLike,
+      });
+    });
+
+    it('preserves deeply nested data without losing fields', async () => {
+      const nested = {
+        user: { id: 1, profile: { bio: 'hi', tags: ['x', 'y'] } },
+        token: 'abc.def.ghi',
+      };
+      expect(await runHandler(nested)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: nested,
+      });
+    });
+  });
+
+  describe('primitive responses', () => {
+    it('wraps a string with result: 1', async () => {
+      expect(await runHandler('Hello World!')).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: 'Hello World!',
+      });
+    });
+
+    it('wraps a string that looks like a date with result: 1', async () => {
+      // Strings have a `.length` property – make sure we still treat
+      // them as a single primitive (not an array of characters).
+      expect(await runHandler('2024-01-01')).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: '2024-01-01',
+      });
+    });
+
+    it('wraps a finite number with result: 1', async () => {
+      expect(await runHandler(42)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: 42,
+      });
+    });
+
+    it('wraps zero with result: 1 (zero is a valid primitive, not an empty array)', async () => {
+      expect(await runHandler(0)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: 0,
+      });
+    });
+
+    it('wraps boolean true with result: 1', async () => {
+      expect(await runHandler(true)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: true,
+      });
+    });
+
+    it('wraps boolean false with result: 1', async () => {
+      expect(await runHandler(false)).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: false,
+      });
+    });
+  });
+
+  describe('null / undefined responses', () => {
+    it('wraps null with result: 0 and data: null', async () => {
+      expect(await runHandler(null)).toEqual({
+        apiversion: API_VERSION,
+        result: 0,
+        data: null,
+      });
+    });
+
+    it('wraps undefined with result: 0 and data: null', async () => {
+      expect(await runHandler(undefined)).toEqual({
+        apiversion: API_VERSION,
+        result: 0,
+        data: null,
+      });
+    });
+  });
+
+  describe('API version field', () => {
+    it('always emits the configured API version (no typo)', async () => {
+      // The legacy field name was `apiversrion` (transposed letters).
+      // We expect the corrected spelling `apiversion` everywhere.
+      const envelope: any = await runHandler({ ok: true });
+      expect(envelope.apiversion).toBe(API_VERSION);
+      expect(envelope.apiversrion).toBeUndefined();
+    });
+  });
+
+  describe('RxJS / interceptor contract', () => {
+    it('returns the envelope asynchronously', async () => {
+      const envelope = await runHandler({ id: 9 });
+      expect(envelope).toMatchObject({
+        apiversion: API_VERSION,
+        result: 1,
+        data: { id: 9 },
+      });
+    });
+
+    it('propagates to subscribers via Observable<Envelope>', async () => {
+      const interceptor = new DataResponseInterceptor<number[]>();
+      const handler: CallHandler<number[]> = { handle: () => of([1, 2, 3]) };
+      const result$ = interceptor.intercept(buildContext(), handler);
+      const collected: any[] = [];
+      result$.subscribe((value) => collected.push(value));
+      expect(collected).toEqual([
+        { apiversion: API_VERSION, result: 3, data: [1, 2, 3] },
+      ]);
+    });
+
+    it('is callable many times without leaking state', async () => {
+      const interceptor = new DataResponseInterceptor();
+      const handlerA: CallHandler = { handle: () => of([1, 2]) };
+      const handlerB: CallHandler = { handle: () => of('a string') };
+      const first = await lastValueFrom(
+        interceptor.intercept(buildContext(), handlerA),
+      );
+      const second = await lastValueFrom(
+        interceptor.intercept(buildContext(), handlerB),
+      );
+      expect(first).toEqual({
+        apiversion: API_VERSION,
+        result: 2,
+        data: [1, 2],
+      });
+      expect(second).toEqual({
+        apiversion: API_VERSION,
+        result: 1,
+        data: 'a string',
+      });
+    });
+  });
+});

--- a/meridian-api/src/common/interceptors/data-response.interceptor.ts
+++ b/meridian-api/src/common/interceptors/data-response.interceptor.ts
@@ -4,17 +4,64 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { map, Observable, pipe, tap } from 'rxjs';
+import { map, Observable } from 'rxjs';
+
+/**
+ * Current API version embedded in every response envelope.
+ * Exported so consumers (other interceptors, integrations tests,
+ * docs) reference a single source of truth.
+ */
+export const API_VERSION = '0.0.1';
+
+/**
+ * Shape of the response envelope applied to every controller
+ * payload. Keeping it as a dedicated type makes the contract
+ * verifiable from tests and gives the IDE something to lean on.
+ */
+export interface DataResponseEnvelope<T> {
+  apiversion: string;
+  result: number;
+  data: T;
+}
 
 @Injectable()
-export class DataResponseInterceptor implements NestInterceptor {
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    return next.handle().pipe(
-      map((data) => ({
-        apiversrion: '0.0.1',
-        result: data.length,
-        data: data,
-      })),
-    );
+export class DataResponseInterceptor<T = unknown> implements NestInterceptor<
+  T,
+  DataResponseEnvelope<T>
+> {
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<DataResponseEnvelope<T>> {
+    return next.handle().pipe(map((data: T) => this.transform(data)));
+  }
+
+  /**
+   * Wrap a controller payload in a uniform envelope:
+   *
+   *   { apiversion: string, result: number, data: T }
+   *
+   * - `Array.isArray(data)` → `result` is the array length.
+   * - Single objects / primitives → `result: 1`.
+   * - `null` / `undefined` → `result: 0, data: null` so clients never
+   *   see a missing or undefined `data` field.
+   *
+   * Plain objects that happen to expose a numeric `length` field are
+   * intentionally NOT treated as arrays – only real JavaScript arrays
+   * (and nothing else) trigger the array branch.
+   *
+   * Exposed as a pure instance method so it can be unit-tested
+   * without standing up the rest of the Nest testing harness.
+   */
+  transform(data: T): DataResponseEnvelope<T> {
+    if (data === null || data === undefined) {
+      return { apiversion: API_VERSION, result: 0, data: null as T };
+    }
+
+    if (Array.isArray(data)) {
+      return { apiversion: API_VERSION, result: data.length, data };
+    }
+
+    return { apiversion: API_VERSION, result: 1, data };
   }
 }


### PR DESCRIPTION
## Summary

Resolves **#426** — the only open issue assigned to **dorisadams**.

The global `DataResponseInterceptor` previously called `.length` on every controller payload, returning 500 errors for endpoints that respond with a single object, primitive, or `null` (`POST /users`, `PATCH /posts`, `DELETE /tweets/:id`, etc.).

### Changes

- **`meridian-api/src/common/interceptors/data-response.interceptor.ts`**
  - Replace `.length` with `Array.isArray(data)` detection.
  - Wrap every response in a uniform envelope `{ apiversion, result, data }`:
    - Real arrays            → `result = data.length`
    - Single objects / primitives → `result = 1`
    - `null` / `undefined`   → `result = 0, data: null`
  - Plain objects with a numeric `length` field are NOT mis-classified as arrays.
  - Fix the `apiversrion` key typo → `apiversion`.
  - Drop unused `pipe` and `tap` rxjs imports.
  - Expose `API_VERSION` constant + `DataResponseEnvelope<T>` typed interface.
  - Expose transformation as a separate `transform()` instance method so it is unit-testable without the rest of the Nest harness.

- **`meridian-api/src/common/interceptors/data-response.interceptor.spec.ts`** *(new)*
  - 21-case spec covering arrays (empty / single / multi), single POJOs, deeply nested data, primitives (strings / numbers / booleans / zero / false), `null`, `undefined`, paginated `{ data, meta }` wrappers, date-shaped strings, objects with numeric `length` field (regression guard), and the Observable contract.

### Verification

- `jest src/common/interceptors/data-response.interceptor.spec.ts` → **21/21 pass**
- `tsc -p tsconfig.build.json --noEmit` → **0 errors**
- `eslint src/common/interceptors/data-response.interceptor.ts src/common/interceptors/data-response.interceptor.spec.ts` → **clean**
- Full `jest` suite shows 3 failing suites in `post/` and `users/` modules (a `deleteUser()` arg signature mismatch + a `DELETE /users` controller integration returning 404). These failures exist on `main` and are unrelated to this change (no files in `post/` or `users/` were touched).

Closes #426