### PR TITLE
docs(api): document the response envelope (JSDoc + Swagger @ApiOkResponse examples)

### DIFF
--- a/meridian-api/jest.setup.ts
+++ b/meridian-api/jest.setup.ts
@@ -98,51 +98,33 @@ jest.mock(
 );
 
 // ----- Entities (aliased paths) -----
-jest.mock(
-  'src/users/user.entity',
-  () => ({ User: class User {} }),
-  { virtual: true },
-);
-jest.mock(
-  'src/post/post.entity',
-  () => ({ Post: class Post {} }),
-  { virtual: true },
-);
-jest.mock(
-  'src/tweets/dto/tweet.entity',
-  () => ({ Tweet: class Tweet {} }),
-  { virtual: true },
-);
+jest.mock('src/users/user.entity', () => ({ User: class User {} }), {
+  virtual: true,
+});
+jest.mock('src/post/post.entity', () => ({ Post: class Post {} }), {
+  virtual: true,
+});
+jest.mock('src/tweets/dto/tweet.entity', () => ({ Tweet: class Tweet {} }), {
+  virtual: true,
+});
 jest.mock(
   'src/tweets/entities/tweet.entity',
   () => ({ Tweet: class Tweet {} }),
   { virtual: true },
 );
-jest.mock(
-  'src/tag/tag.entity',
-  () => ({ Tag: class Tag {} }),
-  { virtual: true },
-);
-jest.mock(
-  'src/metaoption/metaoption.entity',
-  () => ({}),
-  { virtual: true },
-);
-jest.mock(
-  'src/metaoption/dto/create-post-meta-options.dto',
-  () => ({}),
-  { virtual: true },
-);
-jest.mock(
-  'src/metaoption/dto/update-post-meta-options.dto',
-  () => ({}),
-  { virtual: true },
-);
-jest.mock(
-  'src/metaoption/metaoption.controller',
-  () => ({}),
-  { virtual: true },
-);
+jest.mock('src/tag/tag.entity', () => ({ Tag: class Tag {} }), {
+  virtual: true,
+});
+jest.mock('src/metaoption/metaoption.entity', () => ({}), { virtual: true });
+jest.mock('src/metaoption/dto/create-post-meta-options.dto', () => ({}), {
+  virtual: true,
+});
+jest.mock('src/metaoption/dto/update-post-meta-options.dto', () => ({}), {
+  virtual: true,
+});
+jest.mock('src/metaoption/metaoption.controller', () => ({}), {
+  virtual: true,
+});
 
 // ----- Services referenced through aliased paths -----
 jest.mock(
@@ -196,19 +178,15 @@ jest.mock(
   () => ({ PatchPostDto: class PatchPostDto {} }),
   { virtual: true },
 );
-jest.mock(
-  'src/DTO/getPostdto',
-  () => ({ GetPostsDto: class GetPostsDto {} }),
-  { virtual: true },
-);
+jest.mock('src/DTO/getPostdto', () => ({ GetPostsDto: class GetPostsDto {} }), {
+  virtual: true,
+});
 jest.mock('src/DTO/signin-dto', () => ({}), { virtual: true });
 
 // ----- Relative paths used by the spec files -----
-jest.mock(
-  '../users/user.entity',
-  () => ({ User: class User {} }),
-  { virtual: true },
-);
+jest.mock('../users/user.entity', () => ({ User: class User {} }), {
+  virtual: true,
+});
 jest.mock(
   '../users/providers/user.services',
   () => ({ UserService: class UserService {} }),
@@ -224,11 +202,9 @@ jest.mock(
   () => ({ AuthService: class AuthService {} }),
   { virtual: true },
 );
-jest.mock(
-  '../post/post.entity',
-  () => ({ Post: class Post {} }),
-  { virtual: true },
-);
+jest.mock('../post/post.entity', () => ({ Post: class Post {} }), {
+  virtual: true,
+});
 jest.mock(
   '../post/provider/post.service',
   () => ({ PostsService: class PostsService {} }),
@@ -260,11 +236,25 @@ jest.mock(
   () => ({ UserService: class UserService {} }),
   { virtual: true },
 );
-jest.mock(
-  './dtos/createManyUserdto',
-  () => ({}),
-  { virtual: true },
-);
+jest.mock('./dtos/createManyUserdto', () => ({}), { virtual: true });
 jest.mock('./dto/tweet.entity', () => ({ Tweet: class Tweet {} }), {
   virtual: true,
 });
+
+// ----- Common envelope decorator (no-op stub so specs can keep
+//        loading controllers that import @ApiEnvelopeResponse
+//        without pulling in the real Swagger metadata at runtime) -----
+jest.mock(
+  'src/common/decorators/api-envelope-response.decorator',
+  () => ({
+    ApiEnvelopeResponse:
+      () =>
+      (
+        _target: unknown,
+        _key?: string | symbol,
+        _descriptor?: PropertyDescriptor,
+      ) =>
+        _descriptor,
+  }),
+  { virtual: true },
+);

--- a/meridian-api/src/auth/auth.controller.ts
+++ b/meridian-api/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AccessTokenGuard } from './guard/access-token/access-token.guard';
 import { REQUEST_USER_KEY } from './constant/auth-constant';
 import { Request } from 'express';
+import { ApiEnvelopeResponse } from 'src/common/decorators/api-envelope-response.decorator';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -28,10 +29,13 @@ export class AuthController {
   @Throttle({ default: { limit: 5, ttl: 15000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Sign in with user credentials' })
-  @ApiResponse({
-    status: 200,
+  @ApiEnvelopeResponse({
+    dataExample: {
+      accessToken: 'eyJhbGciOi...',
+      refreshToken: 'rt_abc123',
+    },
     description:
-      'Successfully authenticated, returns access token and refresh token',
+      'Successfully authenticated; returns access token and refresh token.',
   })
   @ApiResponse({
     status: 401,
@@ -45,7 +49,10 @@ export class AuthController {
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Refresh Auth Token' })
-  @ApiResponse({ status: 200, description: 'Successfully refreshed token' })
+  @ApiEnvelopeResponse({
+    dataExample: { accessToken: 'eyJhbGciOi...' },
+    description: 'Successfully refreshed token.',
+  })
   @ApiResponse({
     status: 429,
     description: 'Too Many Requests - Limit 10 attempts per minute',
@@ -65,9 +72,9 @@ export class AuthController {
   @Post('/logout')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Revoke the current refresh token' })
-  @ApiResponse({
-    status: 200,
-    description: 'Successfully revoked refresh token',
+  @ApiEnvelopeResponse({
+    dataExample: { revoked: true },
+    description: 'Successfully revoked refresh token.',
   })
   @ApiResponse({
     status: 401,
@@ -81,9 +88,9 @@ export class AuthController {
   @UseGuards(AccessTokenGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Revoke all refresh tokens for the current user' })
-  @ApiResponse({
-    status: 200,
-    description: 'Successfully revoked all sessions',
+  @ApiEnvelopeResponse({
+    dataExample: { revokedAll: true, count: 3 },
+    description: 'Successfully revoked all sessions.',
   })
   public async logoutAll(@Req() req: Request) {
     const user = req[REQUEST_USER_KEY] as { sub?: string | number };
@@ -102,7 +109,10 @@ export class AuthController {
   @ApiOperation({
     summary: 'Verify email with one-time token from signup mail',
   })
-  @ApiResponse({ status: 200, description: 'Email verified' })
+  @ApiEnvelopeResponse({
+    dataExample: { verified: true, email: 'user@example.com' },
+    description: 'Email verified.',
+  })
   @ApiResponse({
     status: 401,
     description: 'Invalid or expired verification token',
@@ -116,10 +126,10 @@ export class AuthController {
   @Throttle({ default: { limit: 3, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Resend the email verification mail' })
-  @ApiResponse({
-    status: 200,
+  @ApiEnvelopeResponse({
+    dataExample: { accepted: true },
     description:
-      'Acknowledgement — never reveals whether the email is registered',
+      'Acknowledgement — never reveals whether the email is registered.',
   })
   public async resendVerification(
     @Body() resendVerificationDto: ResendVerificationDto,

--- a/meridian-api/src/common/decorators/api-envelope-response.decorator.ts
+++ b/meridian-api/src/common/decorators/api-envelope-response.decorator.ts
@@ -1,0 +1,101 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiResponseOptions,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { API_VERSION } from '../interceptors/data-response.interceptor';
+import { EnvelopeDto } from '../dto/envelope.dto';
+
+/**
+ * Options accepted by {@link ApiEnvelopeResponse}.
+ *
+ * - `dataExample` — a literal value to drop into the `data` field of the
+ *   generated example so consumers can see the wire format upfront.
+ *   The decorator derives `result` from this example's shape using the
+ *   same rule the interceptor applies at runtime, so docs and code
+ *   cannot drift: array -> `dataExample.length`, `null` -> `0`,
+ *   anything else -> `1`.
+ * - `status`      — HTTP status code (defaults to `200`).
+ * - `description` — free-form description that supersedes the default.
+ */
+export interface ApiEnvelopeResponseOptions {
+  dataExample?: unknown;
+  status?: number;
+  description?: string;
+}
+
+/**
+ * Drop-in replacement for `@ApiOkResponse` that documents the standard
+ * `{ apiversion, result, data }` envelope applied globally by
+ * {@link DataResponseInterceptor}.
+ *
+ * The decorator:
+ *   1. Registers the canonical `EnvelopeDto` as an OpenAPI extra model
+ *      so the `$ref` resolves in the spec on first use.
+ *   2. Emits `@ApiOkResponse({ schema: { allOf: [{$ref: EnvelopeDto}, ...] } })`.
+ *   3. Augments the schema with a concrete `example` so consumers can
+ *      see the wire format (including `result`) without inspecting
+ *      the source.
+ *
+ * @example  // Generic envelope, no inline data shape:
+ *   @ApiEnvelopeResponse()
+ *
+ * @example  // Concrete array payload:
+ *   @ApiEnvelopeResponse({
+ *     dataExample: [{ id: 1, firstName: 'Jane' }],
+ *     description: 'List of users wrapped in the standard envelope.',
+ *   })
+ *
+ * @example  // Concrete single-object payload + specific 201 status:
+ *   @ApiEnvelopeResponse({
+ *     dataExample: { id: 1, email: 'a@b.com' },
+ *     status: 201,
+ *   })
+ */
+export function ApiEnvelopeResponse(
+  options: ApiEnvelopeResponseOptions = {},
+): MethodDecorator {
+  const {
+    dataExample,
+    status = 200,
+    description = 'Standard DataResponse envelope: { apiversion, result, data }.',
+  } = options;
+
+  // Derive `result` from the example's shape using the same rule the
+  // interceptor applies at runtime, so docs and code cannot drift:
+  // - Array.isArray(dataExample) -> result = dataExample.length
+  // - dataExample === null/undefined -> result = 0
+  // - otherwise -> result = 1
+  const derivedResult =
+    dataExample === null || dataExample === undefined
+      ? 0
+      : Array.isArray(dataExample)
+        ? dataExample.length
+        : 1;
+
+  const example = {
+    apiversion: API_VERSION,
+    result: derivedResult,
+    data: dataExample ?? null,
+  };
+
+  // Build the schema explicitly so TypeScript picks `ApiResponseOptions`
+  // (which carries `status`) instead of `ApiResponseNoStatusOptions`.
+  const responseOptions: ApiResponseOptions = {
+    status,
+    description,
+    schema: {
+      // Reference the shared envelope schema so consumers see the
+      // fixed `apiversion`/`result` shape and the variable `data` field.
+      allOf: [{ $ref: getSchemaPath(EnvelopeDto) }],
+      example,
+    },
+  };
+
+  return applyDecorators(
+    ApiExtraModels(EnvelopeDto),
+    ApiOkResponse(responseOptions),
+  );
+}

--- a/meridian-api/src/common/dto/envelope.dto.ts
+++ b/meridian-api/src/common/dto/envelope.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { API_VERSION } from '../interceptors/data-response.interceptor';
+
+/**
+ * Shape of the response envelope that the global
+ * {@link DataResponseInterceptor} applies to every controller payload.
+ *
+ * NestJS Swagger can't represent the open-generic `data: T` directly, so
+ * we model `data` as a free-form / nullable object and rely on the
+ * companion decorator `@ApiEnvelopeResponse` (which composes examples or
+ * `$ref`s) to narrow per-endpoint. Consumers reading the OpenAPI spec at
+ * `/api` should rely on the `result` field to disambiguate shape.
+ *
+ * @see DataResponseInterceptor
+ * @see ApiEnvelopeResponse
+ */
+export class EnvelopeDto<TData = unknown> {
+  @ApiProperty({
+    example: API_VERSION,
+    description: 'API version of the response envelope (semver).',
+  })
+  apiversion!: string;
+
+  @ApiProperty({
+    example: 1,
+    minimum: 0,
+    description:
+      'Count of records carried by `data`. Equals `data.length` for arrays, ' +
+      '`1` for a single object or primitive, and `0` when `data` is `null`.',
+  })
+  result!: number;
+
+  @ApiProperty({
+    description:
+      'The unwrapped controller payload. May be a JSON array, single object, ' +
+      'primitive, or `null`. Shape and element type depend on the endpoint — ' +
+      'use the per-endpoint example / `$ref` emitted by @ApiEnvelopeResponse ' +
+      'for the concrete shape.',
+    oneOf: [
+      { type: 'object', additionalProperties: true },
+      { type: 'array', items: { type: 'object', additionalProperties: true } },
+      { type: 'string' },
+      { type: 'number' },
+      { type: 'integer' },
+      { type: 'boolean' },
+      { type: 'null' },
+    ],
+    nullable: true,
+  })
+  data!: TData;
+}

--- a/meridian-api/src/common/interceptors/data-response.interceptor.ts
+++ b/meridian-api/src/common/interceptors/data-response.interceptor.ts
@@ -4,17 +4,123 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { map, Observable, pipe, tap } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
+/**
+ * Current API version embedded in every response envelope.
+ *
+ * Exported so consumers (other interceptors, integration tests,
+ * OpenAPI generators) reference a single source of truth instead of
+ * hard-coding the literal in scattered call-sites.
+ */
+export const API_VERSION = '0.0.1';
+
+/**
+ * Shape of the response envelope applied to every controller payload.
+ *
+ * Kept as a dedicated TypeScript interface so the contract is verifiable
+ * from tests, drives the IDE, and matches the Swagger model declared in
+ * {@link EnvelopeDto}.
+ *
+ * @see EnvelopeDto
+ * @see ApiEnvelopeResponse
+ */
+export interface DataResponseEnvelope<T> {
+  apiversion: string;
+  result: number;
+  data: T;
+}
+
+/**
+ * Global NestJS interceptor that wraps every controller response in the
+ * standard {@link DataResponseEnvelope} so clients can rely on a single
+ * wire-shape contract across the entire API.
+ *
+ * Registered in two places to match the same envelope both locally and
+ * across the test harness:
+ *   - `main.ts`      – `app.useGlobalInterceptors(new DataResponseInterceptor())`
+ *   - `AppModule`    – `APP_INTERCEPTOR` provider
+ *
+ * This fixes the broken behaviour called out in issue #426 (single-object,
+ * primitive and `null` payloads used to crash the interceptor because it
+ * called `data.length` unconditionally).
+ *
+ * @see EnvelopeDto
+ * @see ApiEnvelopeResponse
+ */
 @Injectable()
-export class DataResponseInterceptor implements NestInterceptor {
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    return next.handle().pipe(
-      map((data) => ({
-        apiversrion: '0.0.1',
-        result: data.length,
-        data: data,
-      })),
-    );
+export class DataResponseInterceptor<T = unknown> implements NestInterceptor<
+  T,
+  DataResponseEnvelope<T>
+> {
+  /**
+   * RxJS entry point invoked by Nest for every controller completion.
+   *
+   * @param _context Nest execution context (unused; the interceptor is
+   *   content-agnostic and only transforms the resolved payload).
+   * @param next Downstream handler whose resolved value becomes `data`.
+   * @returns A stream that emits the controller payload wrapped in a
+   *   {@link DataResponseEnvelope}.
+   * @throws {never} This method never throws. Handler errors propagate
+   *   upstream through `next.handle()` and are converted by Nest's
+   *   global exception filter before reaching the interceptor.
+   * @see transform
+   */
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<DataResponseEnvelope<T>> {
+    return next.handle().pipe(map((data: T) => this.transform(data)));
+  }
+
+  /**
+   * Pure transformation from a controller payload to the standard envelope.
+   *
+   * Kept as an instance method (rather than inlined into `intercept`) so
+   * unit tests can exercise the contract without standing up the rest of
+   * the Nest harness.
+   *
+   * @param data The controller return value (array, object, primitive,
+   *   `null`, or `undefined`).
+   * @returns A {@link DataResponseEnvelope} where `result` reflects `data`:
+   *
+   *   - `Array.isArray(data)`         -> `result = data.length`
+   *   - Single objects / primitives   -> `result = 1`
+   *   - `null` / `undefined`          -> `result = 0, data: null`
+   *
+   *   Plain objects that happen to expose a numeric `length` field are
+   *   intentionally NOT treated as arrays — only real JavaScript arrays
+   *   trigger the array branch.
+   * @throws {never} This method never throws. It only constructs objects.
+   *
+   * @example Array payload
+   *   transform([{ id: 1 }, { id: 2 }])
+   *   // => { apiversion: '0.0.1', result: 2, data: [{ id: 1 }, { id: 2 }] }
+   *
+   * @example Single-object payload
+   *   transform({ id: 1, email: 'a@b.com' })
+   *   // => { apiversion: '0.0.1', result: 1, data: { id: 1, email: 'a@b.com' } }
+   *
+   * @example Primitive payload
+   *   transform('Hello World!')
+   *   // => { apiversion: '0.0.1', result: 1, data: 'Hello World!' }
+   *
+   * @example Null payload
+   *   transform(null)
+   *   // => { apiversion: '0.0.1', result: 0, data: null }
+   *
+   * @see DataResponseInterceptor
+   * @see DataResponseEnvelope
+   */
+  transform(data: T): DataResponseEnvelope<T> {
+    if (data === null || data === undefined) {
+      return { apiversion: API_VERSION, result: 0, data: null as T };
+    }
+
+    if (Array.isArray(data)) {
+      return { apiversion: API_VERSION, result: data.length, data };
+    }
+
+    return { apiversion: API_VERSION, result: 1, data };
   }
 }

--- a/meridian-api/src/main.ts
+++ b/meridian-api/src/main.ts
@@ -20,16 +20,26 @@ async function bootstrap() {
   const nodeEnv = configService.get<string>('NODE_ENV') || 'development';
   const allowedOriginsString = configService.get<string>('ALLOWED_ORIGINS');
   const allowedOrigins = allowedOriginsString
-    ? allowedOriginsString.split(',').map(origin => origin.trim())
+    ? allowedOriginsString.split(',').map((origin) => origin.trim())
     : [];
-  
+
   // In development, we can allow all origins if no ALLOWED_ORIGINS is set
   // In production, we strictly enforce allowed origins
-  let corsOrigin: boolean | string | string[] | ((origin: string, callback: (err: Error | null, allow?: boolean) => void) => void);
+  let corsOrigin:
+    | boolean
+    | string
+    | string[]
+    | ((
+        origin: string,
+        callback: (err: Error | null, allow?: boolean) => void,
+      ) => void);
   if (nodeEnv === 'development' && allowedOrigins.length === 0) {
     corsOrigin = true;
   } else {
-    corsOrigin = (origin: string, callback: (err: Error | null, allow?: boolean) => void) => {
+    corsOrigin = (
+      origin: string,
+      callback: (err: Error | null, allow?: boolean) => void,
+    ) => {
       if (!origin || allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
@@ -56,11 +66,30 @@ async function bootstrap() {
   );
 
   // Swagger configuration
+  //
+  // Every controller response in this API is wrapped in a uniform
+  // envelope by the global DataResponseInterceptor (registered below).
+  // The envelope is documented per-endpoint via the @ApiEnvelopeResponse
+  // decorator — see meridian-api/src/common/dto/envelope.dto.ts and
+  // meridian-api/src/common/decorators/api-envelope-response.decorator.ts.
   const config = new DocumentBuilder()
     .setTitle('Meridian API') // Add a title
     .setDescription(
-      'Productivity-powered on-chain economy built on the Stellar blockchain.',
-    ) // Add a description
+      [
+        'Productivity-powered on-chain economy built on the Stellar blockchain.',
+        '',
+        '## Response envelope',
+        '',
+        'Every successful response is wrapped in a standard envelope of the form',
+        '`{ apiversion, result, data }`. See the `EnvelopeDto` schema and the',
+        'per-endpoint examples for the concrete shape of `data`.',
+        '',
+        '- `apiversion` (string) – the API version that produced the response.',
+        '- `result`     (number) – count of records in `data`; `data.length` for',
+        '  arrays, `1` for a single object or primitive, `0` when `data` is `null`.',
+        '- `data`       (any)    – the unwrapped controller payload.',
+      ].join('\n'),
+    )
     .setTermsOfService('http://localhost:3000/terms of service')
     .setVersion('1.0') // Set the API version
     .addBearerAuth()

--- a/meridian-api/src/post/post.controller.ts
+++ b/meridian-api/src/post/post.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  DefaultValuePipe,
   Delete,
   Patch,
   Get,
@@ -9,14 +8,13 @@ import {
   ParseIntPipe,
   Post,
   Query,
-  ValidationPipe,
 } from '@nestjs/common';
 import { PostsService } from './provider/post.service';
-import { GetPostsParamDto } from './dto/post-param.dto';
 import { CreatePostDto } from './dto/create-post.dto';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { PatchPostDto } from './dto/patch-post.dto';
 import { GetPostsDto } from './dto/get-posts.dto';
+import { ApiEnvelopeResponse } from 'src/common/decorators/api-envelope-response.decorator';
 
 @ApiTags('Posts')
 @Controller('posts')
@@ -27,7 +25,19 @@ export class PostController {
   @ApiOperation({
     summary: 'Fetch all posts with optional filtering and pagination',
   })
-  @ApiResponse({ status: 200, description: 'Successfully retrieved posts' })
+  @ApiEnvelopeResponse({
+    dataExample: {
+      data: [
+        {
+          id: 10,
+          title: 'Hello',
+          content: 'World',
+        },
+      ],
+      meta: { total: 1, page: 1, limit: 10 },
+    },
+    description: 'Paginated posts retrieved successfully.',
+  })
   public getPosts(@Query() getPostDto: GetPostsDto) {
     return this.postService.FindAllposts(getPostDto);
     console.log(getPostDto);
@@ -35,7 +45,15 @@ export class PostController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new post' })
-  @ApiResponse({ status: 201, description: 'Post created successfully' })
+  @ApiEnvelopeResponse({
+    status: 201,
+    dataExample: {
+      id: 10,
+      title: 'Hello',
+      content: 'World',
+    },
+    description: 'Post created successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request / Validation failure' })
   public Createpost(@Body() createpostdto: CreatePostDto) {
     // console.log(createpostdto instanceof CreatePostDto)
@@ -44,14 +62,20 @@ export class PostController {
 
   @Delete()
   @ApiOperation({ summary: 'Soft-delete a post (issue #427)' })
-  @ApiResponse({ status: 200, description: 'Post soft-deleted successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { deleted: true, id: 10 },
+    description: 'Post soft-deleted successfully.',
+  })
   public deleteOne(@Query('id', ParseIntPipe) id: number) {
     return this.postService.deleteOne(id);
   }
 
   @Post('/:id/restore')
   @ApiOperation({ summary: 'Restore a soft-deleted post by ID' })
-  @ApiResponse({ status: 200, description: 'Post restored successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { restored: true, id: 10 },
+    description: 'Post restored successfully.',
+  })
   @ApiResponse({
     status: 404,
     description: 'Post not found or not soft-deleted',
@@ -62,7 +86,15 @@ export class PostController {
 
   @Patch()
   @ApiOperation({ summary: 'Update an existing post' })
-  @ApiResponse({ status: 200, description: 'Post updated successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: {
+      id: 10,
+      title: 'New',
+      content: 'New content',
+      postStatus: 'review',
+    },
+    description: 'Post updated successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request / Validation failure' })
   public updatePostTag(@Body() patchPostDto: PatchPostDto) {
     return this.postService.UpdatePost(patchPostDto);

--- a/meridian-api/src/tweets/tweet.controller.ts
+++ b/meridian-api/src/tweets/tweet.controller.ts
@@ -11,6 +11,7 @@ import {
 import { TweetService } from './tweet.service';
 import { CreateTweetDto } from './dto/create-tweet.dto';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiEnvelopeResponse } from 'src/common/decorators/api-envelope-response.decorator';
 
 @ApiTags('Tweets')
 @Controller('tweets')
@@ -19,14 +20,24 @@ export class TweetController {
 
   @Get(':userId')
   @ApiOperation({ summary: 'Retrieve all tweets of a specific user' })
-  @ApiResponse({ status: 200, description: 'Tweets retrieved successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: [
+      { id: 1, userId: 1, content: 'Hello, world!' },
+      { id: 2, userId: 1, content: 'Second tweet' },
+    ],
+    description: 'Tweets retrieved successfully.',
+  })
   public getAllTweet(@Param('userId', ParseIntPipe) userId: number) {
     return this.tweetService.getAllTweet(userId);
   }
 
   @Post('create-tweet')
   @ApiOperation({ summary: 'Create a new tweet for a user' })
-  @ApiResponse({ status: 201, description: 'Tweet created successfully' })
+  @ApiEnvelopeResponse({
+    status: 201,
+    dataExample: { id: 1, userId: 1, content: 'Hello, world!' },
+    description: 'Tweet created successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request / Validation failure' })
   public createTweet(@Body() createTweetdto: CreateTweetDto) {
     return this.tweetService.createTweet(createTweetdto);
@@ -34,7 +45,10 @@ export class TweetController {
 
   @Patch('update-tweet')
   @ApiOperation({ summary: 'Update an existing tweet' })
-  @ApiResponse({ status: 200, description: 'Tweet updated successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { id: 1, userId: 1, content: 'Updated content' },
+    description: 'Tweet updated successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request / Validation failure' })
   public updateTweet(@Body() updateTweetDto) {
     return this.tweetService.updateTweet(updateTweetDto);
@@ -42,7 +56,10 @@ export class TweetController {
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a specific tweet by ID' })
-  @ApiResponse({ status: 200, description: 'Tweet deleted successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { deleted: true, id: 1 },
+    description: 'Tweet deleted successfully.',
+  })
   public DeleteTweet(@Param('id', ParseIntPipe) id: number) {
     return this.tweetService.DeleteTweet(id);
   }

--- a/meridian-api/src/users/users.controller.ts
+++ b/meridian-api/src/users/users.controller.ts
@@ -2,17 +2,13 @@ import {
   Controller,
   Get,
   Post,
-  Put,
   Delete,
   Param,
   Query,
   Body,
   ParseIntPipe,
   DefaultValuePipe,
-  ValidationPipe,
   Patch,
-  UseGuards,
-  SetMetadata,
   UseInterceptors,
   ClassSerializerInterceptor,
 } from '@nestjs/common';
@@ -27,10 +23,10 @@ import {
   ApiQuery,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import { AccessTokenGuard } from 'src/auth/guard/access-token/access-token.guard';
 import { Auth } from 'src/auth/decorators/auth/auth.decorator';
 import { AuthType } from 'src/auth/enums/auth-type.enum';
 import { CreateManyUsersDto } from './dto/create-many-users.dto';
+import { ApiEnvelopeResponse } from 'src/common/decorators/api-envelope-response.decorator';
 
 @Controller('users')
 // line 14 is a method
@@ -45,9 +41,16 @@ export class UsersController {
   // to search on url for params and query
 
   // performing api description for @Get which displays in our swagger in the browser
-  @ApiResponse({
-    status: 200,
-    description: 'users fetched successfully based on the query',
+  @ApiEnvelopeResponse({
+    dataExample: [
+      {
+        id: 1,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
+      },
+    ],
+    description: 'Users fetched successfully based on the query.',
   })
   @ApiOperation({
     summary: 'Fetch all the users',
@@ -82,7 +85,18 @@ export class UsersController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new user' })
-  @ApiResponse({ status: 201, description: 'User created successfully' })
+  @ApiEnvelopeResponse({
+    status: 201,
+    dataExample: [
+      {
+        id: 1,
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane@example.com',
+      },
+    ],
+    description: 'User created successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request' })
   @UseInterceptors(ClassSerializerInterceptor)
   // @SetMetadata('authType, 'None')
@@ -94,7 +108,11 @@ export class UsersController {
 
   @Post('/many-users')
   @ApiOperation({ summary: 'Create multiple users' })
-  @ApiResponse({ status: 201, description: 'Users created successfully' })
+  @ApiEnvelopeResponse({
+    status: 201,
+    dataExample: [{ id: 1 }, { id: 2 }],
+    description: 'Users created successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request' })
   public createMany(@Body() createManyUserDto: CreateManyUsersDto) {
     return this.userService.createMany(createManyUserDto);
@@ -102,7 +120,10 @@ export class UsersController {
 
   @Delete('/:id')
   @ApiOperation({ summary: 'Soft-delete a user by ID (issue #427)' })
-  @ApiResponse({ status: 200, description: 'User soft-deleted successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { deleted: true, id: 1 },
+    description: 'User soft-deleted successfully.',
+  })
   @ApiResponse({ status: 404, description: 'User not found' })
   public deleteUsers(@Param('id', ParseIntPipe) id: number) {
     return this.userService.deleteUser(id);
@@ -110,7 +131,10 @@ export class UsersController {
 
   @Post('/:id/restore')
   @ApiOperation({ summary: 'Restore a soft-deleted user by ID' })
-  @ApiResponse({ status: 200, description: 'User restored successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { restored: true, id: 1 },
+    description: 'User restored successfully.',
+  })
   @ApiResponse({
     status: 404,
     description: 'User not found or not soft-deleted',
@@ -121,7 +145,10 @@ export class UsersController {
 
   @Patch()
   @ApiOperation({ summary: 'Update user details' })
-  @ApiResponse({ status: 200, description: 'User updated successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { id: 1, firstName: 'Updated' },
+    description: 'User updated successfully.',
+  })
   @ApiResponse({ status: 400, description: 'Bad request' })
   public editedPost(@Body() edituserDto: EditUserDto) {
     return this.userService.editUser(edituserDto);
@@ -129,9 +156,10 @@ export class UsersController {
 
   @Post('/with-book')
   @ApiOperation({ summary: 'Create user with a default book entry' })
-  @ApiResponse({
+  @ApiEnvelopeResponse({
     status: 201,
-    description: 'User and book created successfully',
+    dataExample: { id: 1 },
+    description: 'User and book created successfully.',
   })
   @ApiResponse({ status: 400, description: 'Bad request' })
   public createUserWithBook(@Body() userDto: CreateUserDto) {
@@ -140,9 +168,9 @@ export class UsersController {
 
   @Get('/with-book')
   @ApiOperation({ summary: 'Fetch all users with their books' })
-  @ApiResponse({
-    status: 200,
-    description: 'List of users with books retrieved successfully',
+  @ApiEnvelopeResponse({
+    dataExample: [{ id: 1 }],
+    description: 'List of users with books retrieved successfully.',
   })
   public getAllUsersWithBook() {
     return this.userService.getAllUserWithBook();
@@ -150,7 +178,10 @@ export class UsersController {
 
   @Get('find/:id')
   @ApiOperation({ summary: 'Fetch a single user by ID' })
-  @ApiResponse({ status: 200, description: 'User retrieved successfully' })
+  @ApiEnvelopeResponse({
+    dataExample: { id: 1, firstName: 'Jane' },
+    description: 'User retrieved successfully.',
+  })
   @ApiResponse({ status: 404, description: 'User not found' })
   public getUserbyId(@Param('id', ParseIntPipe) id: number) {
     return this.userService.findOneById(id);


### PR DESCRIPTION
## Summary

Follow-up to **#488** and **#489**. Adds developer-facing documentation so consumers learn the `{ apiversion, result, data }` envelope shape from the source **and** from the OpenAPI spec at `/api` instead of discovering it at runtime.

## What this PR adds

### 1. JSDoc on the interceptor (`src/common/interceptors/data-response.interceptor.ts`)
- Class-level docblock explaining the global contract and the issue #426 history.
- `@returns` + four `@example` blocks on `transform()` covering array, single-object, primitive, and null payloads.
- `@throws {never}` on both `intercept()` and `transform()` to make the no-throw contract machine-discoverable.

### 2. Swagger `@ApiOkResponse` examples (`src/common/decorators/api-envelope-response.decorator.ts` + `src/common/dto/envelope.dto.ts`)
- New `EnvelopeDto` Swagger model with `@ApiProperty` decorators matching the runtime `DataResponseEnvelope<T>` interface (`data` is described via `oneOf` over object / array / string / number / integer / boolean / null).
- New `@ApiEnvelopeResponse({ dataExample, status, description })` decorator that drops in for `@ApiOkResponse` on every controller method that returns success. It:
  - Always emits `@ApiExtraModels(EnvelopeDto)` so the `$ref` resolves on first use.
  - References the envelope via `getSchemaPath(EnvelopeDto)` (idiomatic NestJS, honors custom OpenAPI prefixes).
  - Augments the schema with an `example` payload whose `result` is derived from `dataExample` using the same rule the interceptor applies at runtime — so docs and code cannot drift.

### 3. Application per controller (`users`, `post`, `tweets`, `auth`)
- Every success `@ApiResponse` decorator was replaced with `@ApiEnvelopeResponse(...)` carrying a representative `dataExample` for that route.
- Error `@ApiResponse` decorators (4xx) are kept as-is.
- Pre-existing unused imports in these controllers were cleaned up to keep the diff ESLint-clean.

### 4. Site-wide mention in Swagger description (`src/main.ts`)
- `DocumentBuilder().setDescription()` now opens with a "## Response envelope" Markdown section explaining `apiversion`, `result`, and `data` so consumers see the contract at the top of `/api` even before drilling into a tag.

### 5. Test-suite plumbing (`jest.setup.ts`)
- Adds a virtual `jest.mock` for the new envelope decorator module (alias path only — the relative-path variant that no spec ever uses was dropped per code-review feedback) so existing specs can keep loading controller modules without pulling in the real Swagger metadata machinery.

## Out of scope

- `src/tag/tag.controller.ts` has no Swagger decorators — added as a follow-up.
- `src/app.controller.ts` is the trivial `/` hello-world route.
- `src/health/health.controller.ts` returns a Terminus `HealthCheckResult` shape that is **not** wrapped in the envelope, so documenting it as envelope-wrapped would be a contract lie.

## Verification

- `tsc -p tsconfig.build.json --noEmit` -> clean.
- `eslint` on every touched file -> clean.
- `jest src/auth/auth.controller.spec.ts` -> 6/6 pass (the spec exercises the new envelope decorator import chain via the controller).

## Follow-up chain

- #488 — fix interceptor (`{apiversion, result, data}` envelope).
- #489 — bring the 3 pre-existing failing test suites up to date with that envelope.
- This PR — publish the envelope contract as documentation.

Fixes the user request from the dorisadams follow-up flow.