### PR TITLE
fix(test): close envelope regression-lock contract — 31/31 green against post-#488 source

### DIFF
--- a/meridian-api/src/common/interceptors/data-response.interceptor.ts
+++ b/meridian-api/src/common/interceptors/data-response.interceptor.ts
@@ -4,17 +4,64 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { map, Observable, pipe, tap } from 'rxjs';
+import { map, Observable } from 'rxjs';
+
+/**
+ * Current API version embedded in every response envelope.
+ * Exported so consumers (other interceptors, integrations tests,
+ * docs) reference a single source of truth.
+ */
+export const API_VERSION = '0.0.1';
+
+/**
+ * Shape of the response envelope applied to every controller
+ * payload. Keeping it as a dedicated type makes the contract
+ * verifiable from tests and gives the IDE something to lean on.
+ */
+export interface DataResponseEnvelope<T> {
+  apiversion: string;
+  result: number;
+  data: T;
+}
 
 @Injectable()
-export class DataResponseInterceptor implements NestInterceptor {
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    return next.handle().pipe(
-      map((data) => ({
-        apiversrion: '0.0.1',
-        result: data.length,
-        data: data,
-      })),
-    );
+export class DataResponseInterceptor<T = unknown> implements NestInterceptor<
+  T,
+  DataResponseEnvelope<T>
+> {
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<DataResponseEnvelope<T>> {
+    return next.handle().pipe(map((data: T) => this.transform(data)));
+  }
+
+  /**
+   * Wrap a controller payload in a uniform envelope:
+   *
+   *   { apiversion: string, result: number, data: T }
+   *
+   * - `Array.isArray(data)` → `result` is the array length.
+   * - Single objects / primitives → `result: 1`.
+   * - `null` / `undefined` → `result: 0, data: null` so clients never
+   *   see a missing or undefined `data` field.
+   *
+   * Plain objects that happen to expose a numeric `length` field are
+   * intentionally NOT treated as arrays – only real JavaScript arrays
+   * (and nothing else) trigger the array branch.
+   *
+   * Exposed as a pure instance method so it can be unit-tested
+   * without standing up the rest of the Nest testing harness.
+   */
+  transform(data: T): DataResponseEnvelope<T> {
+    if (data === null || data === undefined) {
+      return { apiversion: API_VERSION, result: 0, data: null as T };
+    }
+
+    if (Array.isArray(data)) {
+      return { apiversion: API_VERSION, result: data.length, data };
+    }
+
+    return { apiversion: API_VERSION, result: 1, data };
   }
 }

--- a/meridian-api/test/data-response.interceptor.auth.e2e-spec.ts
+++ b/meridian-api/test/data-response.interceptor.auth.e2e-spec.ts
@@ -1,0 +1,258 @@
+/**
+ * E2E regression lock for issue #426 (fixed in #488), AuthController slice.
+ *
+ * Compiles a real Nest testing app with:
+ *   - the actual `DataResponseInterceptor` registered as APP_INTERCEPTOR
+ *   - the actual `AuthController`
+ *   - a mocked `AuthService` whose return values are deterministic
+ * and asserts that every route shape (single object only — auth never
+ * returns arrays) is wrapped in the `{ apiversion, result, data }`
+ * envelope and the response is never a 500 due to a TypeError in the
+ * interceptor.
+ *
+ * Special plumbing notes:
+ *
+ *   - `AccessTokenGuard` is referenced via
+ *     `@UseGuards(AccessTokenGuard)` on the `logoutAll` route. We mock
+ *     the guard to `canActivate() => true` so its JWT verification
+ *     chain doesn't need to boot inside the e2e test app.
+ *   - `@Throttle()` decorators from `@nestjs/throttler` are inert in
+ *     our isolated test app because `ThrottlerGuard` (registered via
+ *     `APP_GUARD` in AppModule) is NOT installed here. They're
+ *     metadata-only at decoration time.
+ *
+ * If a future refactor re-introduces raw `data.length` access (or any
+ * other shape-breaking transformation), this spec fails loudly at the
+ * HTTP layer on the auth routes.
+ *
+ * Run with `npm run test:e2e`.
+ */
+
+import { INestApplication } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+import {
+  API_VERSION,
+  expectEnvelopeShape,
+  expectNoEnvelopeKeys,
+} from './helpers/envelope-assert.helper';
+import { DataResponseInterceptor } from '../src/common/interceptors/data-response.interceptor';
+import { AuthController } from '../src/auth/auth.controller';
+import { AuthService } from '../src/auth/providers/auth.service';
+
+// Mock AccessTokenGuard so the @UseGuards() decorator on `logoutAll`
+// doesn't pull JwtService + jwt.config into the test app. The mock
+// faithfully reproduces the real guard's contract: it stamps a
+// verified JWT payload onto req[REQUEST_USER_KEY] so the controller's
+// `req[REQUEST_USER_KEY].sub` lookup succeeds and the handler
+// reaches `authService.logoutAll(sub)`.
+jest.mock(
+  'src/auth/guard/access-token/access-token.guard',
+  () => ({
+    AccessTokenGuard: class AccessTokenGuard {
+      canActivate(context: {
+        switchToHttp: () => { getRequest: () => Record<string, unknown> };
+      }): boolean {
+        const req = context.switchToHttp().getRequest();
+        req['user'] = { sub: 42 };
+        return true;
+      }
+    },
+  }),
+  { virtual: true },
+);
+
+// jest.setup.ts (wired in via jest-e2e.json `setupFiles`) already stubs
+// AuthService class, UserService class, all auth provider modules
+// (sign-in.providers, refreshToken.provider, verify-email.provider,
+// hashing, token.provider), the User entity, and most auth DTOs — no
+// per-spec `jest.mock()` calls are needed for those.
+
+interface AuthServiceMock {
+  SignIn: jest.Mock;
+  RefreshToken: jest.Mock;
+  logout: jest.Mock;
+  logoutAll: jest.Mock;
+  verifyEmail: jest.Mock;
+  resendVerification: jest.Mock;
+}
+
+describe('DataResponseInterceptor (e2e, AuthController slice, issue #426 regression lock)', () => {
+  let app: INestApplication;
+  let authService: AuthServiceMock;
+
+  beforeEach(async () => {
+    authService = {
+      SignIn: jest.fn(async () => ({
+        accessToken: 'jwt.access.mock',
+        refreshToken: 'jwt.refresh.mock',
+      })),
+      RefreshToken: jest.fn(async () => ({
+        accessToken: 'jwt.access.refreshed',
+      })),
+      logout: jest.fn(async () => ({ revoked: true })),
+      logoutAll: jest.fn(async () => ({ revokedAll: true, count: 3 })),
+      verifyEmail: jest.fn(async (token: string) => ({
+        email: `user-${token}@example.com`,
+      })),
+      resendVerification: jest.fn(async () => ({
+        status: 'ok',
+        message:
+          'If that email belongs to an unverified account, a new verification email has been sent.',
+      })),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: APP_INTERCEPTOR, useClass: DataResponseInterceptor },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('single-object responses (the regression bug)', () => {
+    it('POST /auth/sign-in -> { apiversion, result: 1, data: <tokens> }', async () => {
+      const dto = { email: 'jane@example.com', password: 'Password123!' };
+      const response = await request(app.getHttpServer())
+        .post('/auth/sign-in')
+        .send(dto);
+
+      // @HttpCode(HttpStatus.OK) overrides Nest's default 201 for POST.
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: {
+          accessToken: 'jwt.access.mock',
+          refreshToken: 'jwt.refresh.mock',
+        },
+      });
+      expect(authService.SignIn).toHaveBeenCalledWith(dto);
+    });
+
+    it('POST /auth/refresh-token -> { apiversion, result: 1, data: <token> }', async () => {
+      const dto = { refreshToken: 'jwt.refresh.mock' };
+      const response = await request(app.getHttpServer())
+        .post('/auth/refresh-token')
+        .send(dto);
+
+      // @HttpCode(HttpStatus.OK) overrides Nest's default 201 for POST.
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { accessToken: 'jwt.access.refreshed' },
+      });
+      expect(authService.RefreshToken).toHaveBeenCalled();
+    });
+
+    it('POST /auth/logout -> { apiversion, result: 1, data: {revoked: true} }', async () => {
+      const dto = { refreshToken: 'jwt.refresh.mock' };
+      const response = await request(app.getHttpServer())
+        .post('/auth/logout')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { revoked: true },
+      });
+    });
+
+    it('POST /auth/logout-all (guarded) -> { apiversion, result: 1, data: <summary> }', async () => {
+      // The mocked AccessTokenGuard stamps req[REQUEST_USER_KEY] with
+      // { sub: 42 } so the handler reaches authService.logoutAll(42)
+      // and the success envelope is what we lock.
+      const response = await request(app.getHttpServer()).post(
+        '/auth/logout-all',
+      );
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { revokedAll: true, count: 3 },
+      });
+      expect(authService.logoutAll).toHaveBeenCalledWith(42);
+    });
+
+    it('POST /auth/verify-email -> { apiversion, result: 1, data: {verified:true, email} }', async () => {
+      const dto = { token: 'tok-abc' };
+      const response = await request(app.getHttpServer())
+        .post('/auth/verify-email')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      // The controller returns { verified: true, email: user.email }
+      // directly, not via authService.verifyEmail. So we assert the
+      // shape produced by the controller's wrapping.
+      const body = response.body as {
+        apiversion: string;
+        result: number;
+        data: { verified: boolean; email: string };
+      };
+      expect(body.apiversion).toBe(API_VERSION);
+      expect(body.result).toBe(1);
+      expect(body.data.verified).toBe(true);
+      expect(typeof body.data.email).toBe('string');
+    });
+
+    it('POST /auth/resend-verification -> { apiversion, result: 1, data: {status, message} }', async () => {
+      const dto = { email: 'jane@example.com' };
+      const response = await request(app.getHttpServer())
+        .post('/auth/resend-verification')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: {
+          status: 'ok',
+          message:
+            'If that email belongs to an unverified account, a new verification email has been sent.',
+        },
+      });
+      expect(authService.resendVerification).toHaveBeenCalledWith(dto.email);
+    });
+  });
+
+  describe('exception path isolation', () => {
+    it('POST /auth/sign-in error -> AuthService rejection bypasses the envelope', async () => {
+      // Force the auth service to reject with an Error. Nest's
+      // BaseExceptionFilter returns 500; assert the body has no
+      // envelope keys.
+      authService.SignIn.mockRejectedValueOnce(
+        new Error('forced sign-in error'),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/auth/sign-in')
+        .send({ email: 'x@y', password: 'p' });
+
+      expect(response.status).toBe(500);
+      expect(authService.SignIn).toHaveBeenCalled();
+      expectNoEnvelopeKeys(response.body);
+    });
+  });
+
+  describe('envelope structural invariants', () => {
+    it('always sets apiversion to API_VERSION and never emits the legacy typo', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/auth/logout')
+        .send({ refreshToken: 'jwt.refresh.mock' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiversion).toBe(API_VERSION);
+      expect(
+        (response.body as Record<string, unknown>).apiversrion,
+      ).toBeUndefined();
+    });
+  });
+});

--- a/meridian-api/test/data-response.interceptor.auth.e2e-spec.ts
+++ b/meridian-api/test/data-response.interceptor.auth.e2e-spec.ts
@@ -10,12 +10,27 @@
  * envelope and the response is never a 500 due to a TypeError in the
  * interceptor.
  *
- * Special plumbing notes:
+ * Guard override notes:
  *
- *   - `AccessTokenGuard` is referenced via
- *     `@UseGuards(AccessTokenGuard)` on the `logoutAll` route. We mock
- *     the guard to `canActivate() => true` so its JWT verification
- *     chain doesn't need to boot inside the e2e test app.
+ *   - `AuthController.logoutAll` declares `@UseGuards(AccessTokenGuard)`.
+ *     The real guard has a `JwtService` constructor dependency that
+ *     requires `@Inject('JWT_SECRET')` + JwtModule registration to boot.
+ *     We replace the guard entirely via NestJS's
+ *     `.overrideGuard(AccessTokenGuard).useValue(...)` chain — this
+ *     prevents NestJS from ever invoking the real guard's constructor,
+ *     so neither JwtService nor the JWT_SECRET token needs to be in
+ *     scope. The override replicates the real guard's contract: it
+ *     stamps a verified JWT payload onto `req.user` so the controller's
+ *     `req.user.sub` lookup resolves and the handler reaches
+ *     `authService.logoutAll(sub)`.
+ *
+ *   - A previous attempt used `jest.mock('src/auth/guard/...access-token.guard',
+ *     { virtual: true })` — but the controller imports the guard via a
+ *     relative path (`'../auth/guard/access-token/access-token.guard'`),
+ *     so the virtual-path mock never intercepted the controller's import.
+ *     `overrideGuard` is the canonical NestJS pattern and avoids the
+ *     path-mismatch trap entirely.
+ *
  *   - `@Throttle()` decorators from `@nestjs/throttler` are inert in
  *     our isolated test app because `ThrottlerGuard` (registered via
  *     `APP_GUARD` in AppModule) is NOT installed here. They're
@@ -39,30 +54,9 @@ import {
   expectNoEnvelopeKeys,
 } from './helpers/envelope-assert.helper';
 import { DataResponseInterceptor } from '../src/common/interceptors/data-response.interceptor';
+import { AccessTokenGuard } from '../src/auth/guard/access-token/access-token.guard';
 import { AuthController } from '../src/auth/auth.controller';
 import { AuthService } from '../src/auth/providers/auth.service';
-
-// Mock AccessTokenGuard so the @UseGuards() decorator on `logoutAll`
-// doesn't pull JwtService + jwt.config into the test app. The mock
-// faithfully reproduces the real guard's contract: it stamps a
-// verified JWT payload onto req[REQUEST_USER_KEY] so the controller's
-// `req[REQUEST_USER_KEY].sub` lookup succeeds and the handler
-// reaches `authService.logoutAll(sub)`.
-jest.mock(
-  'src/auth/guard/access-token/access-token.guard',
-  () => ({
-    AccessTokenGuard: class AccessTokenGuard {
-      canActivate(context: {
-        switchToHttp: () => { getRequest: () => Record<string, unknown> };
-      }): boolean {
-        const req = context.switchToHttp().getRequest();
-        req['user'] = { sub: 42 };
-        return true;
-      }
-    },
-  }),
-  { virtual: true },
-);
 
 // jest.setup.ts (wired in via jest-e2e.json `setupFiles`) already stubs
 // AuthService class, UserService class, all auth provider modules
@@ -110,7 +104,23 @@ describe('DataResponseInterceptor (e2e, AuthController slice, issue #426 regress
         { provide: AuthService, useValue: authService },
         { provide: APP_INTERCEPTOR, useClass: DataResponseInterceptor },
       ],
-    }).compile();
+    })
+      .overrideGuard(AccessTokenGuard)
+      .useValue({
+        canActivate: (
+          context: {
+            switchToHttp: () => { getRequest: () => Record<string, unknown> };
+          },
+        ): boolean => {
+          // Replicates the real guard's contract: stamps the verified
+          // JWT payload onto req.user so the @UseGuards-protected
+          // logoutAll handler reaches authService.logoutAll().
+          const req = context.switchToHttp().getRequest();
+          req['user'] = { sub: 42 };
+          return true;
+        },
+      })
+      .compile();
 
     app = moduleRef.createNestApplication();
     await app.init();
@@ -168,9 +178,9 @@ describe('DataResponseInterceptor (e2e, AuthController slice, issue #426 regress
     });
 
     it('POST /auth/logout-all (guarded) -> { apiversion, result: 1, data: <summary> }', async () => {
-      // The mocked AccessTokenGuard stamps req[REQUEST_USER_KEY] with
-      // { sub: 42 } so the handler reaches authService.logoutAll(42)
-      // and the success envelope is what we lock.
+      // The overrideGuard stamps req.user with { sub: 42 } so the
+      // handler reaches authService.logoutAll(42) and the success
+      // envelope is what we lock.
       const response = await request(app.getHttpServer()).post(
         '/auth/logout-all',
       );

--- a/meridian-api/test/data-response.interceptor.e2e-spec.ts
+++ b/meridian-api/test/data-response.interceptor.e2e-spec.ts
@@ -1,0 +1,248 @@
+/**
+ * E2E regression lock for issue #426 (fixed in #488).
+ *
+ * Before the fix the global `DataResponseInterceptor` called
+ * `data.length` on every controller payload, which threw a TypeError
+ * for single-object, primitive and `null` responses and surfaced to
+ * clients as a 500. This spec compiles a real Nest testing app with
+ *   - the actual `DataResponseInterceptor` registered as APP_INTERCEPTOR
+ *   - the actual `UsersController`
+ *   - a mocked `UserService` whose return values are deterministic
+ * and drives every category of payload (single object, array, `null`)
+ * through `supertest`, asserting the wire shape is always
+ * `{ apiversion, result, data }` and the response is never a 500
+ * caused by a TypeError in the interceptor.
+ *
+ * If a future refactor re-introduces raw `data.length` access (or any
+ * other shape-breaking transformation), this spec will fail loudly at
+ * the HTTP layer.
+ *
+ * Run with `npm run test:e2e`.
+ */
+
+import { INestApplication } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+// ----- Inline mocks for the symbols UsersController / the envelope
+//        decorator pull in but jest.setup.ts (wired in via
+//        jest-e2e.json `setupFiles`) does not cover. Entity chain,
+//        DTOs, auth provider modules and pagination are stubbed by the
+//        shared setup file so we don't have to repeat them here.
+jest.mock(
+  'src/auth/enums/auth-type.enum',
+  () => ({
+    AuthType: { Bearer: 0, None: 1 },
+  }),
+  { virtual: true },
+);
+jest.mock(
+  'src/auth/decorators/auth/auth.decorator',
+  () => ({
+    Auth: () => () => undefined,
+  }),
+  { virtual: true },
+);
+jest.mock(
+  'src/common/decorators/api-envelope-response.decorator',
+  () => ({
+    ApiEnvelopeResponse: () => () => undefined,
+  }),
+  { virtual: true },
+);
+
+// The version literal this spec asserts every `apiversion` field
+// carries. Post-#488 the interceptor exports API_VERSION with this
+// same value; pre-#488 it's hard-coded inside the buggy `apiversrion`
+// literal. Either way the wire shape on `main` today is '0.0.1', so
+// the spec locks against that constant.
+//
+// DRIFT WARNING: if a future PR bumps the interceptor's
+// API_VERSION export, this literal must be updated in lockstep,
+// otherwise the spec silently locks the OLD value. A test failure
+// on a same-major version bump is acceptable but a silent drift
+// is not.
+const API_VERSION = '0.0.1';
+
+import { DataResponseInterceptor } from '../src/common/interceptors/data-response.interceptor';
+import { UsersController } from '../src/users/users.controller';
+import { UserService } from '../src/users/providers/user.services';
+
+describe('DataResponseInterceptor (e2e, issue #426 regression lock)', () => {
+  let app: INestApplication;
+  let userService: {
+    findAll: jest.Mock;
+    findOneById: jest.Mock;
+    deleteUser: jest.Mock;
+    restoreUser: jest.Mock;
+    editUser: jest.Mock;
+  };
+  beforeEach(async () => {
+    userService = {
+      findAll: jest.fn(async () => [
+        { id: 1, firstName: 'Jane', email: 'jane@example.com' },
+        { id: 2, firstName: 'John', email: 'john@example.com' },
+      ]),
+      findOneById: jest.fn(async (id: number) =>
+        id === 1 ? { id, firstName: 'Jane' } : null,
+      ),
+      deleteUser: jest.fn(async (id: number) => ({ deleted: true, id })),
+      restoreUser: jest.fn(async (id: number) => ({ restored: true, id })),
+      editUser: jest.fn(async (dto: Record<string, unknown>) => ({
+        id: dto.id,
+        firstName: 'Updated',
+      })),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        { provide: UserService, useValue: userService },
+        { provide: APP_INTERCEPTOR, useClass: DataResponseInterceptor },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    // Pipe + global error filter is intentionally omitted so the spec
+    // focuses entirely on the interceptor contract. Disable body
+    // parsing is also not needed – supertest handles payloads fine.
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('single-object responses (the regression bug)', () => {
+    it('DELETE /users/:id -> { apiversion, result: 1, data: {deleted, id} }', async () => {
+      // Before #426 the buggy interceptor tried
+      // `({deleted,id}).length` and threw a TypeError -> 500.
+      const response = await request(app.getHttpServer()).delete('/users/1');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 1,
+        data: { deleted: true, id: 1 },
+      });
+      expect(userService.deleteUser).toHaveBeenCalledWith(1);
+    });
+
+    it('POST /users/:id/restore -> { apiversion, result: 1, data: {restored, id} }', async () => {
+      const response = await request(app.getHttpServer()).post(
+        '/users/1/restore',
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 1,
+        data: { restored: true, id: 1 },
+      });
+      expect(userService.restoreUser).toHaveBeenCalledWith(1);
+    });
+
+    it('PATCH /users -> { apiversion, result: 1, data: <user> }', async () => {
+      const dto = { id: 1, firstName: 'Updated' };
+      const response = await request(app.getHttpServer())
+        .patch('/users')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 1,
+        data: { id: 1, firstName: 'Updated' },
+      });
+      expect(userService.editUser).toHaveBeenCalled();
+    });
+
+    it('GET /users/find/:id (hit) -> { apiversion, result: 1, data: <user> }', async () => {
+      const response = await request(app.getHttpServer()).get('/users/find/1');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 1,
+        data: { id: 1, firstName: 'Jane' },
+      });
+      expect(userService.findOneById).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('null responses', () => {
+    it('GET /users/find/:id (miss) -> { apiversion, result: 0, data: null }', async () => {
+      // The source returns `null` when the row is missing; the
+      // interceptor MUST surface that as `{ result: 0, data: null }`
+      // rather than crashing or stringifying.
+      const response = await request(app.getHttpServer()).get(
+        '/users/find/404',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 0,
+        data: null,
+      });
+      expect(userService.findOneById).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('array responses', () => {
+    it('GET /users -> { apiversion, result: N, data: [...] }', async () => {
+      const response = await request(app.getHttpServer()).get('/users');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        apiversion: API_VERSION,
+        result: 2,
+      });
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data).toHaveLength(2);
+      expect(response.body.data[0]).toEqual({
+        id: 1,
+        firstName: 'Jane',
+        email: 'jane@example.com',
+      });
+    });
+  });
+
+  describe('envelope structural invariants', () => {
+    it('always sets apiversion to API_VERSION and never emits the legacy typo', async () => {
+      const response = await request(app.getHttpServer()).get('/users/find/1');
+
+      expect(response.status).toBe(200);
+      // Regression guard: the original buggy code shipped a typo'd
+      // `apiversrion` literal; the fixed interceptor must emit the
+      // corrected `apiversion` and never the misspelled one.
+      expect(response.body.apiversion).toBe(API_VERSION);
+      expect(response.body.apiversrion).toBeUndefined();
+    });
+  });
+
+  describe('exception path isolation', () => {
+    it('exceptions bypass the interceptor entirely (no `data` key in body)', async () => {
+      // If a route handler rejects with an HttpException (or any Error),
+      // Nest's exception filter converts it BEFORE the interceptor sees
+      // it. The wire shape is the exception JSON
+      // ({statusCode, message, ...}) — NOT the envelope. Verify both
+      // the 500 status AND that the response body has no envelope keys.
+      userService.findOneById.mockRejectedValueOnce(new Error('forced'));
+
+      const response = await request(app.getHttpServer()).get('/users/find/1');
+
+      expect(response.status).toBe(500);
+      // Spy assertion: prove we hit the service (and therefore the
+      // rejected path), not a phantom 500 from somewhere else.
+      expect(userService.findOneById).toHaveBeenCalledWith(1);
+      // Sharper regression lock: a regression that wraps errors inside
+      // the envelope would surface an `apiversion` + `data` key here.
+      // A real Nest exception filter response uses `statusCode` /
+      // `message` instead, which is what we want.
+      expect(response.body).not.toHaveProperty('data');
+      expect(response.body).not.toHaveProperty('apiversion');
+    });
+  });
+});

--- a/meridian-api/test/data-response.interceptor.post.e2e-spec.ts
+++ b/meridian-api/test/data-response.interceptor.post.e2e-spec.ts
@@ -1,0 +1,221 @@
+/**
+ * E2E regression lock for issue #426 (fixed in #488), PostController slice.
+ *
+ * Compiles a real Nest testing app with:
+ *   - the actual `DataResponseInterceptor` registered as APP_INTERCEPTOR
+ *   - the actual `PostController`
+ *   - a mocked `PostsService` whose return values are deterministic
+ * and asserts that every route shape is wrapped in the
+ * `{ apiversion, result, data }` envelope and that a 500 from a
+ * TypeError in the interceptor never escapes.
+ *
+ * If a future refactor re-introduces raw `data.length` access (or any
+ * other shape-breaking transformation), this spec will fail loudly at
+ * the HTTP layer on the post routes.
+ *
+ * Run with `npm run test:e2e`.
+ */
+
+import { HttpException, INestApplication } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+import {
+  API_VERSION,
+  expectEnvelopeShape,
+  expectNoEnvelopeKeys,
+} from './helpers/envelope-assert.helper';
+import { DataResponseInterceptor } from '../src/common/interceptors/data-response.interceptor';
+import { PostController } from '../src/post/post.controller';
+import { PostsService } from '../src/post/provider/post.service';
+
+// jest.setup.ts (wired in via jest-e2e.json `setupFiles`) already stubs
+// Post entity chain, PostsService class, TagsService class,
+// pagination provider, UserService, and the post DTOs — no per-spec
+// `jest.mock()` calls are needed for those.
+
+interface PostsServiceMock {
+  FindAllposts: jest.Mock;
+  createPost: jest.Mock;
+  deleteOne: jest.Mock;
+  restorePost: jest.Mock;
+  UpdatePost: jest.Mock;
+}
+
+describe('DataResponseInterceptor (e2e, PostController slice, issue #426 regression lock)', () => {
+  let app: INestApplication;
+  let postService: PostsServiceMock;
+
+  beforeEach(async () => {
+    postService = {
+      FindAllposts: jest.fn(async () => ({
+        data: [
+          { id: 1, title: 'Hello' },
+          { id: 2, title: 'World' },
+        ],
+        meta: {
+          itemsPerPage: 10,
+          totalItems: 2,
+          currentPage: 1,
+          totalPages: 1,
+        },
+      })),
+      createPost: jest.fn(async (dto: Record<string, unknown>) => ({
+        id: 99,
+        title: dto.title,
+        slug: 'post-99',
+      })),
+      deleteOne: jest.fn(async (id: number) => ({ deleted: true, id })),
+      restorePost: jest.fn(async (id: number) => ({ restored: true, id })),
+      UpdatePost: jest.fn(async (dto: Record<string, unknown>) => ({
+        id: dto.id,
+        title: 'Updated',
+      })),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PostController],
+      providers: [
+        { provide: PostsService, useValue: postService },
+        { provide: APP_INTERCEPTOR, useClass: DataResponseInterceptor },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('single-object responses (the regression bug)', () => {
+    it('POST /posts -> { apiversion, result: 1, data: <post> }', async () => {
+      const dto = {
+        title: 'New Post',
+        authorId: 1,
+        postType: 'post',
+        PostStatus: 'draft',
+        tags: [1, 2],
+      };
+      const response = await request(app.getHttpServer())
+        .post('/posts')
+        .send(dto);
+
+      expect(response.status).toBe(201);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { id: 99, title: 'New Post' },
+      });
+      expect(postService.createPost).toHaveBeenCalled();
+    });
+
+    it('PATCH /posts -> { apiversion, result: 1, data: <updated-post> }', async () => {
+      const dto = { id: 1, title: 'Updated Title' };
+      const response = await request(app.getHttpServer())
+        .patch('/posts')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { id: 1, title: 'Updated' },
+      });
+      expect(postService.UpdatePost).toHaveBeenCalledWith(dto);
+    });
+
+    it('POST /posts/:id/restore -> { apiversion, result: 1, data: {restored: true, id} }', async () => {
+      const response = await request(app.getHttpServer()).post(
+        '/posts/1/restore',
+      );
+
+      expect(response.status).toBe(201);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { restored: true, id: 1 },
+      });
+      expect(postService.restorePost).toHaveBeenCalledWith(1);
+    });
+
+    it('DELETE /posts?id=N -> { apiversion, result: 1, data: {deleted: true, id} }', async () => {
+      // Source uses @Query('id', ParseIntPipe) for deleteOne.
+      const response = await request(app.getHttpServer()).delete('/posts?id=7');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { deleted: true, id: 7 },
+      });
+      expect(postService.deleteOne).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('paginated-object responses (single-object envelope, NOT array)', () => {
+    // GetPostsDto returns Paginated<Post> = { data: Post[], meta: {...} }.
+    // The interceptor must treat the outer shape as a single object and
+    // wrap it as result: 1, data: <paginated>. A bug where the
+    // interceptor recursed into `.data` would surface as
+    // result: <array.length>, data: <paginated>. Lock against the
+    // correct behavior here.
+    it('GET /posts -> { apiversion, result: 1, data: <paginated> }', async () => {
+      const response = await request(app.getHttpServer()).get('/posts');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: {
+          meta: {
+            itemsPerPage: 10,
+            totalItems: 2,
+            currentPage: 1,
+            totalPages: 1,
+          },
+        },
+      });
+      // Inner array must remain inside `data.data` (i.e. the interceptor
+      // did NOT flatten it).
+      const inner = (response.body.data as { data: unknown[] }).data;
+      expect(Array.isArray(inner)).toBe(true);
+      expect(inner).toHaveLength(2);
+    });
+  });
+
+  describe('exception path isolation', () => {
+    it('POST /posts/404/restore -> 404 with no envelope keys on the body', async () => {
+      // Restore throws HttpException(404) when nothing is restorable.
+      // Nest's exception filter converts it BEFORE the interceptor sees
+      // it, so the wire shape is the exception JSON — NOT the envelope.
+      // Lock against two regression modes: (a) status code, (b) no
+      // envelope keys leaking into the error body.
+      postService.restorePost.mockRejectedValueOnce(
+        new HttpException(
+          {
+            status: 404,
+            error: 'Post with id 404 was not found or is not soft-deleted',
+          },
+          404,
+        ),
+      );
+
+      const response = await request(app.getHttpServer()).post(
+        '/posts/404/restore',
+      );
+
+      expect(response.status).toBe(404);
+      expectNoEnvelopeKeys(response.body);
+    });
+  });
+
+  describe('envelope structural invariants', () => {
+    it('always sets apiversion to API_VERSION and never emits the legacy typo', async () => {
+      const response = await request(app.getHttpServer()).delete('/posts?id=1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiversion).toBe(API_VERSION);
+      expect(
+        (response.body as Record<string, unknown>).apiversrion,
+      ).toBeUndefined();
+    });
+  });
+});

--- a/meridian-api/test/data-response.interceptor.tweets.e2e-spec.ts
+++ b/meridian-api/test/data-response.interceptor.tweets.e2e-spec.ts
@@ -1,0 +1,203 @@
+/**
+ * E2E regression lock for issue #426 (fixed in #488), TweetController slice.
+ *
+ * Compiles a real Nest testing app with:
+ *   - the actual `DataResponseInterceptor` registered as APP_INTERCEPTOR
+ *   - the actual `TweetController`
+ *   - a mocked `TweetService` whose return values are deterministic
+ * and asserts that every route shape (single object, array, null) is
+ * wrapped in the `{ apiversion, result, data }` envelope and the
+ * response is never a 500 due to a TypeError in the interceptor.
+ *
+ * If a future refactor re-introduces raw `data.length` access (or any
+ * other shape-breaking transformation), this spec fails loudly at the
+ * HTTP layer on the tweets routes.
+ *
+ * Run with `npm run test:e2e`.
+ */
+
+import { INestApplication, NotFoundException } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+
+import {
+  API_VERSION,
+  expectEnvelopeShape,
+  expectNoEnvelopeKeys,
+} from './helpers/envelope-assert.helper';
+import { DataResponseInterceptor } from '../src/common/interceptors/data-response.interceptor';
+import { TweetController } from '../src/tweets/tweet.controller';
+import { TweetService } from '../src/tweets/tweet.service';
+
+// jest.setup.ts (wired in via jest-e2e.json `setupFiles`) already stubs
+// Tweet entity class, UserService class, and the tweet DTOs — no
+// per-spec `jest.mock()` calls are needed for those.
+
+interface TweetServiceMock {
+  getAllTweet: jest.Mock;
+  createTweet: jest.Mock;
+  updateTweet: jest.Mock;
+  DeleteTweet: jest.Mock;
+}
+
+describe('DataResponseInterceptor (e2e, TweetController slice, issue #426 regression lock)', () => {
+  let app: INestApplication;
+  let tweetService: TweetServiceMock;
+
+  beforeEach(async () => {
+    tweetService = {
+      getAllTweet: jest.fn(async (userId: number) =>
+        userId === 404
+          ? null // pre-#488 this branch was never reachable due to the NotFoundException throw
+          : [
+              { id: 1, userId, text: 'Hello' },
+              { id: 2, userId, text: 'World' },
+            ],
+      ),
+      createTweet: jest.fn(async (dto: Record<string, unknown>) => ({
+        id: 100,
+        userId: dto.userId,
+        text: dto.text,
+      })),
+      updateTweet: jest.fn(async (dto: Record<string, unknown>) => ({
+        id: dto.id,
+        text: dto.text ?? 'Untouched',
+      })),
+      DeleteTweet: jest.fn(async (id: number) => ({ deleted: true, id })),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TweetController],
+      providers: [
+        { provide: TweetService, useValue: tweetService },
+        { provide: APP_INTERCEPTOR, useClass: DataResponseInterceptor },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('single-object responses (the regression bug)', () => {
+    it('POST /tweets/create-tweet -> { apiversion, result: 1, data: <tweet> }', async () => {
+      const dto = { userId: 1, text: 'A new tweet' };
+      const response = await request(app.getHttpServer())
+        .post('/tweets/create-tweet')
+        .send(dto);
+
+      expect(response.status).toBe(201);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { id: 100, userId: 1, text: 'A new tweet' },
+      });
+      expect(tweetService.createTweet).toHaveBeenCalledWith(dto);
+    });
+
+    it('PATCH /tweets/update-tweet -> { apiversion, result: 1, data: <tweet> }', async () => {
+      const dto = { id: 7, text: 'Edited tweet' };
+      const response = await request(app.getHttpServer())
+        .patch('/tweets/update-tweet')
+        .send(dto);
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { id: 7, text: 'Edited tweet' },
+      });
+      expect(tweetService.updateTweet).toHaveBeenCalledWith(dto);
+    });
+
+    it('DELETE /tweets/:id -> { apiversion, result: 1, data: {deleted: true, id} }', async () => {
+      const response = await request(app.getHttpServer()).delete('/tweets/42');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, {
+        result: 1,
+        data: { deleted: true, id: 42 },
+      });
+      expect(tweetService.DeleteTweet).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe('array responses', () => {
+    it('GET /tweets/:userId -> { apiversion, result: N, data: [...] }', async () => {
+      const response = await request(app.getHttpServer()).get('/tweets/1');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, { result: 2 });
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data).toHaveLength(2);
+      expect(response.body.data[0]).toEqual({
+        id: 1,
+        userId: 1,
+        text: 'Hello',
+      });
+      expect(tweetService.getAllTweet).toHaveBeenCalledWith(1);
+    });
+
+    it('GET /tweets/:userId (empty result) -> { apiversion, result: 0, data: [] }', async () => {
+      // Override the BeforeEach default (which returns two items for
+      // userId=1) so we exercise the array-with-no-items branch of the
+      // interceptor.
+      tweetService.getAllTweet.mockResolvedValueOnce([]);
+
+      const response = await request(app.getHttpServer()).get('/tweets/1');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, { result: 0, data: [] });
+      expect(tweetService.getAllTweet).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('null responses', () => {
+    it('GET /tweets/:userId (null payload) -> { apiversion, result: 0, data: null }', async () => {
+      // Mock returns null for userId 404 (the service throws before
+      // returning null in production, but the interceptor’s branching
+      // contract requires that a null payload surface as
+      // `{ result: 0, data: null }`). Override per-test so we hit the
+      // null-returning branch without exercising the throw path.
+      tweetService.getAllTweet.mockResolvedValueOnce(null);
+
+      const response = await request(app.getHttpServer()).get('/tweets/13');
+
+      expect(response.status).toBe(200);
+      expectEnvelopeShape(response.body, { result: 0, data: null });
+    });
+  });
+
+  describe('exception path isolation', () => {
+    it('NotFoundException bypasses the interceptor (no `data` key in body)', async () => {
+      // TweetService throws NotFoundException when the user is missing.
+      // The exception filter converts it BEFORE the interceptor runs,
+      // so the wire shape is the Nest 404 payload — NOT the envelope.
+      tweetService.getAllTweet.mockRejectedValueOnce(
+        new NotFoundException('User with 999 not found'),
+      );
+
+      const response = await request(app.getHttpServer()).get('/tweets/999');
+
+      expect(response.status).toBe(404);
+      expectNoEnvelopeKeys(response.body);
+      // Sanity-check: the exception filter's signature keys are present.
+      expect(response.body).toHaveProperty('statusCode');
+      expect(response.body).toHaveProperty('message');
+    });
+  });
+
+  describe('envelope structural invariants', () => {
+    it('always sets apiversion to API_VERSION and never emits the legacy typo', async () => {
+      const response = await request(app.getHttpServer()).delete('/tweets/1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiversion).toBe(API_VERSION);
+      expect(
+        (response.body as Record<string, unknown>).apiversrion,
+      ).toBeUndefined();
+    });
+  });
+});

--- a/meridian-api/test/helpers/envelope-assert.helper.ts
+++ b/meridian-api/test/helpers/envelope-assert.helper.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared helpers for the DataResponseInterceptor e2e specs.
+ *
+ * Centralises the API_VERSION literal and the wire-shape matchers that
+ * each per-controller spec asserts, so the suite stays in lockstep when
+ * the contract changes (one file to update, not five).
+ */
+
+// The version literal that every envelope `apiversion` field must carry.
+// Pre-#488 the interceptor hard-codes this inside a typo'd `apiversrion`
+// literal; post-#488 it is exported as API_VERSION. Either way the wire
+// shape on `main` today is '0.0.1', so the spec family locks against
+// that constant here.
+//
+// DRIFT WARNING: if a future PR bumps the interceptor's API_VERSION
+// export, this literal MUST be updated in lockstep, otherwise the
+// envelope specs will silently lock the OLD value. A test failure on a
+// same-major version bump is acceptable; a silent drift is not.
+export const API_VERSION = '0.0.1';
+
+/**
+ * Asserts that a 2xx supertest response body conforms to the
+ * `{ apiversion, result, data }` envelope. Uses `toMatchObject` (not
+ * `toEqual`) so adding future optional envelope fields does not
+ * cascade-test-fail.
+ */
+export function expectEnvelopeShape(
+  body: unknown,
+  expected: { result: number; data?: unknown },
+): void {
+  expect(body).toMatchObject({
+    apiversion: API_VERSION,
+    result: expected.result,
+    ...(expected.data !== undefined ? { data: expected.data } : {}),
+  });
+}
+
+/**
+ * Asserts that a non-2xx (typically 4xx/5xx) supertest response body
+ * is the Nest exception-filter JSON shape and NOT the envelope. Catches
+ * future regressions that wrap errors inside the envelope.
+ */
+export function expectNoEnvelopeKeys(body: unknown): void {
+  const obj = body as Record<string, unknown> | null | undefined;
+  expect(obj).not.toBeNull();
+  expect(obj).not.toHaveProperty('data');
+  expect(obj).not.toHaveProperty('apiversion');
+  expect(obj).not.toHaveProperty('result');
+}

--- a/meridian-api/test/jest-e2e.json
+++ b/meridian-api/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "setupFiles": ["../jest.setup.ts"]
 }


### PR DESCRIPTION
## Summary

Resolves the envelope regression-lock contract at **31/31 jest GREEN** against the post-#488 interceptor source materialised on a feature branch.

## Commits

- `fa8cbef3` — `fix(api): apply post-#488 interceptor source`

  Cherry-picks the post-#488 source byte-identical from PR #488 (`fix/issue-426-data-response-interceptor`). Verified via `diff -q` against `https://github.com/MERIDIAN-CITY/Meridians-verse/commits/fix/issue-426-data-response-interceptor`.

- `77532e4` — `fix(test): use overrideGuard to bypass AccessTokenGuard constructor DI`

  Closes tracking issue #499. Replaces the prior failing `jest.mock('src/auth/guard/...access-token.guard', { virtual: true })` (whose virtual-path target didn't match the controller's actual relative-path import) with NestJS's canonical `.overrideGuard(AccessTokenGuard).useValue({ canActivate: ... })`. The override replicates the real guard's contract (stamps `req.user = { sub: 42 }` so the logoutAll handler reaches `authService.logoutAll(42)`).

## Verification

On the local branch `test/e2e-data-response-interceptor`, jest produces:

```
Test Suites: 4 passed, 4 total
Tests:       31 passed, 31 total
```

Capture: `/tmp/envelope-results-override.json` (numTotalTests=31, numPassedTests=31, numFailedTests=0, success=true).

## Cross-references

- **Tracking issue #499** — `auth-slice spec: provide JwtService to RootTestModule` — closed by `77532e4`.
- **Tracking chain #498** — `PR #488 → #491 → #496 deployment order`.
- **PR #488** — the interceptor fix (`fix(api): harden DataResponseInterceptor for non-array responses`).
- **PR #491** — the four envelope regression-lock e2e specs (post-e2e-spec, post-spec, tweets-spec, auth-spec).
- **PR #496** — CI annotation for envelope regression-lock PR runs.

## Files changed (relative to `test/e2e-data-response-interceptor`)

- `meridian-api/src/common/interceptors/data-response.interceptor.ts` — post-#488 source (cherry-picked in `fa8cbef3`).
- `meridian-api/test/data-response.interceptor.auth.e2e-spec.ts` — overrideGuard spec fix (in `77532e4`).

## Source of compaction

This branch should land on `main` BEFORE PR #488 (so the lock specs + overrideGuard fix run against the post-#488 source). After landing this branch, PR #491 (lock specs) and PR #496 (CI annotation) can drop into main without surprises.
