### PR TITLE
test(api): update deleteUser test to handle non-existent user case

### DIFF
--- a/meridian-api/src/users/providers/user.service.spec.ts
+++ b/meridian-api/src/users/providers/user.service.spec.ts
@@ -133,7 +133,8 @@ describe('UserService', () => {
   });
 
   it('deleteUser throws HttpException', async () => {
-    await expect(service.deleteUser()).rejects.toThrow(HttpException);
+    usersRepository.findOneBy.mockResolvedValueOnce(null);
+    await expect(service.deleteUser(999)).rejects.toThrow(HttpException);
   });
 
   it('createMany delegates to the createManyUserService', async () => {


### PR DESCRIPTION
Closes #493 

### Summary
Fixed a pre-existing TypeScript test failure in user.service.spec.ts caused by calling `service.deleteUser()` with no arguments even though production code requires `id: number`.

### What changed
- Updated the failing spec:
  - `await expect(service.deleteUser()).rejects.toThrow(HttpException);`
  - to:
    - `usersRepository.findOneBy.mockResolvedValueOnce(null);`
    - `await expect(service.deleteUser(999)).rejects.toThrow(HttpException);`
- This preserves the original intent of testing the error branch while satisfying the required method signature.

### Why it was broken
- `UserService.deleteUser(id: number)` requires a numeric `id`
- The spec called it without arguments, producing `TS2554: Expected 1 arguments, but got 0`
- This caused the whole user.service.spec.ts suite to fail before any tests ran

### Files changed
- user.service.spec.ts

### Result
- The spec now exercises the not-found branch correctly
- The compile-time error is removed
- The test is aligned with production behavior for `deleteUser()`