### PR TITLE
fix(api): add softDelete mock to post service spec (pre-existing fail…

### DIFF
--- a/meridian-api/src/post/provider/post.service.spec.ts
+++ b/meridian-api/src/post/provider/post.service.spec.ts
@@ -76,6 +76,8 @@ describe('PostsService', () => {
     postRepository = {
       find: jest.fn(),
       delete: jest.fn(),
+      softDelete: jest.fn(),
+      restore: jest.fn(),
       create: jest.fn((dto) => ({ id: 10, ...dto })),
       save: jest.fn(async (post) => post),
       findOneBy: jest.fn(),
@@ -114,10 +116,10 @@ describe('PostsService', () => {
   });
 
   describe('deleteOne', () => {
-    it('deletes a post by id and returns the deletion summary', async () => {
-      postRepository.delete.mockResolvedValue({ affected: 1 });
+    it('soft-deletes a post by id and returns the deletion summary', async () => {
+      postRepository.softDelete.mockResolvedValue({ affected: 1 });
       const result = await service.deleteOne(10);
-      expect(postRepository.delete).toHaveBeenCalledWith(10);
+      expect(postRepository.softDelete).toHaveBeenCalledWith(10);
       expect(result).toEqual({ deleted: true, id: 10 });
     });
   });


### PR DESCRIPTION
## Description

Pre-existing test failure in `post.service.spec.ts` — unrelated to PR #491 / issue #425.

### Root cause

Production code at `src/post/provider/post.service.ts:45` calls `this.postRepository.softDelete(id)`, but the mock in `src/post/provider/post.service.spec.ts:77-86` only stubs `find`, `delete`, `create`, `save`, and `findOneBy`. `softDelete` (and `restore`, used by `restorePost` at line 55) were missing, causing `TypeError: this.postRepository.softDelete is not a function` on any test exercising the soft-delete path.

Additionally, the `deleteOne` test was calling `postRepository.delete` instead of `postRepository.softDelete`, so it was testing the wrong method and would never fail even if the mock was present.

### Changes

1. Added `softDelete: jest.fn()` and `restore: jest.fn()` to the `postRepository` mock
2. Updated the `deleteOne` test to call `softDelete` (matching production) instead of `delete`

Closes #492 