### PR TITLE
feat: reusable form composition kit with React Hook Form + Zod (meridian-web)

### DIFF
--- a/meridian-web/app/auth/sign-in/page.tsx
+++ b/meridian-web/app/auth/sign-in/page.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+import { FormWrapper } from '@/components/form/FormWrapper'
+import { FormInput } from '@/components/form/FormInput'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { SignInSchema, type SignInDto } from '@/lib/validations/auth'
+
+const DEFAULT_VALUES: SignInDto = { email: '', password: '' }
+
+export default function SignInPage() {
+  const router = useRouter()
+
+  async function handleSignIn(data: SignInDto) {
+    const res = await fetch('/api/auth/signin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+
+    if (!res.ok) {
+      const body = (await res.json()) as { message?: string }
+      toast.error(body?.message ?? 'Sign-in failed. Please try again.')
+      return
+    }
+
+    toast.success('Signed in successfully!')
+    router.push('/')
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-1 text-center">
+          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+          <p className="text-muted-foreground text-sm">
+            Enter your email and password to continue.
+          </p>
+        </div>
+
+        <FormWrapper
+          schema={SignInSchema}
+          defaultValues={DEFAULT_VALUES}
+          onSubmit={handleSignIn}
+          className="space-y-4"
+        >
+          {({ formState: { isSubmitting, isValid } }) => (
+            <>
+              <FormInput<SignInDto>
+                name="email"
+                label="Email"
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                description="The email you registered with."
+              />
+
+              <FormInput<SignInDto>
+                name="password"
+                label="Password"
+                type="password"
+                placeholder="••••••••"
+                autoComplete="current-password"
+              />
+
+              <Button
+                type="submit"
+                className="w-full"
+                disabled={isSubmitting || !isValid}
+              >
+                {isSubmitting ? (
+                  <span className="flex items-center gap-2">
+                    <Spinner className="size-4" />
+                    Signing in…
+                  </span>
+                ) : (
+                  'Sign in'
+                )}
+              </Button>
+            </>
+          )}
+        </FormWrapper>
+      </div>
+    </main>
+  )
+}

--- a/meridian-web/components/form/FormInput.tsx
+++ b/meridian-web/components/form/FormInput.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { type FieldPath, type FieldValues, useFormContext } from 'react-hook-form'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+const formInputVariants = cva('', {
+  variants: {
+    variant: {
+      default: '',
+      destructive: 'text-destructive',
+      warning: 'text-yellow-600 dark:text-yellow-400',
+      info: 'text-blue-600 dark:text-blue-400',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+})
+
+interface FormInputProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> extends VariantProps<typeof formInputVariants>,
+    Omit<React.ComponentProps<'input'>, 'name'> {
+  name: TName
+  label: string
+  description?: string
+  labelClassName?: string
+}
+
+export function FormInput<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  name,
+  label,
+  description,
+  variant,
+  labelClassName,
+  className,
+  ...inputProps
+}: FormInputProps<TFieldValues, TName>) {
+  const { control } = useFormContext<TFieldValues>()
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel className={cn(formInputVariants({ variant }), labelClassName)}>
+            {label}
+          </FormLabel>
+          <FormControl>
+            <Input {...field} {...inputProps} className={className} />
+          </FormControl>
+          {description && <FormDescription>{description}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/meridian-web/components/form/FormSelect.tsx
+++ b/meridian-web/components/form/FormSelect.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { type FieldPath, type FieldValues, useFormContext } from 'react-hook-form'
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+interface FormSelectProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  name: TName
+  label: string
+  options: SelectOption[]
+  placeholder?: string
+  description?: string
+  disabled?: boolean
+}
+
+export function FormSelect<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  name,
+  label,
+  options,
+  placeholder = 'Select an option',
+  description,
+  disabled,
+}: FormSelectProps<TFieldValues, TName>) {
+  const { control } = useFormContext<TFieldValues>()
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <Select
+            onValueChange={field.onChange}
+            defaultValue={field.value as string | undefined}
+            disabled={disabled}
+          >
+            <FormControl>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={placeholder} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {options.map(opt => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {description && <FormDescription>{description}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/meridian-web/components/form/FormTextarea.tsx
+++ b/meridian-web/components/form/FormTextarea.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { type FieldPath, type FieldValues, useFormContext } from 'react-hook-form'
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+
+interface FormTextareaProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> extends Omit<React.ComponentProps<'textarea'>, 'name'> {
+  name: TName
+  label: string
+  description?: string
+  labelClassName?: string
+}
+
+export function FormTextarea<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  name,
+  label,
+  description,
+  labelClassName,
+  className,
+  ...textareaProps
+}: FormTextareaProps<TFieldValues, TName>) {
+  const { control } = useFormContext<TFieldValues>()
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel className={cn(labelClassName)}>{label}</FormLabel>
+          <FormControl>
+            <Textarea
+              {...field}
+              {...textareaProps}
+              className={className}
+            />
+          </FormControl>
+          {description && <FormDescription>{description}</FormDescription>}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/meridian-web/components/form/FormWrapper.tsx
+++ b/meridian-web/components/form/FormWrapper.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  useForm,
+  type DefaultValues,
+  type FieldValues,
+  type SubmitHandler,
+} from 'react-hook-form'
+import type { z, ZodType } from 'zod'
+
+import { Form } from '@/components/ui/form'
+
+interface FormWrapperProps<TSchema extends ZodType<FieldValues>> {
+  schema: TSchema
+  defaultValues: DefaultValues<z.infer<TSchema>>
+  onSubmit: SubmitHandler<z.infer<TSchema>>
+  children: (methods: ReturnType<typeof useForm<z.infer<TSchema>>>) => React.ReactNode
+  className?: string
+}
+
+export function FormWrapper<TSchema extends ZodType<FieldValues>>({
+  schema,
+  defaultValues,
+  onSubmit,
+  children,
+  className,
+}: FormWrapperProps<TSchema>) {
+  const methods = useForm<z.infer<TSchema>>({
+    resolver: zodResolver(schema),
+    defaultValues,
+    mode: 'onTouched',
+  })
+
+  return (
+    <Form {...methods}>
+      <form
+        onSubmit={methods.handleSubmit(onSubmit)}
+        className={className}
+        noValidate
+      >
+        {children(methods)}
+      </form>
+    </Form>
+  )
+}

--- a/meridian-web/lib/validations/auth.ts
+++ b/meridian-web/lib/validations/auth.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+export const SignInSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Enter a valid email address'),
+  password: z
+    .string()
+    .min(1, 'Password is required')
+    .min(8, 'Password must be at least 8 characters'),
+})
+
+export type SignInDto = z.infer<typeof SignInSchema>
+
+export const RegisterSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Enter a valid email address'),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .regex(/[A-Z]/, 'Must contain an uppercase letter')
+    .regex(/[0-9]/, 'Must contain a number'),
+  confirmPassword: z.string().min(1, 'Please confirm your password'),
+})
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  })
+
+export type RegisterDto = z.infer<typeof RegisterSchema>
+
+export const PatchUserSchema = z.object({
+  displayName: z
+    .string()
+    .min(2, 'Display name must be at least 2 characters')
+    .max(64, 'Display name must be 64 characters or fewer')
+    .optional(),
+  bio: z.string().max(256, 'Bio must be 256 characters or fewer').optional(),
+})
+
+export type PatchUserDto = z.infer<typeof PatchUserSchema>


### PR DESCRIPTION
## Summary

Implements a reusable, type-safe form composition layer for the meridian-web frontend, mirroring the shape of backend DTOs.

### Files added
- lib/validations/auth.ts - Zod schemas (SignInSchema, RegisterSchema, PatchUserSchema) matching backend DTOs
- components/form/FormWrapper.tsx - Generic wrapper with Zod schema, default values, submit handler, render-prop children
- components/form/FormInput.tsx - FormInput primitive with class-variance-authority variant support
- components/form/FormSelect.tsx - FormSelect primitive wrapping the existing shadcn Select
- components/form/FormTextarea.tsx - FormTextarea primitive wrapping the existing shadcn Textarea
- app/auth/sign-in/page.tsx - Production sign-in page demo with Spinner loading state and sonner toasts

### Design decisions
- All primitives use useFormContext so they compose freely inside any FormWrapper without prop-drilling
- SignInSchema field names match SignInDto on the backend exactly
- Loading state surfaces the existing Spinner from components/ui/spinner.tsx
- No third-party data-fetching library; sign-in page uses plain fetch compatible with Server Actions

closes #438