### PR TITLE
bug fixed

### DIFF
--- a/meridian-contracts/contracts/property-token/src/lib.rs
+++ b/meridian-contracts/contracts/property-token/src/lib.rs
@@ -1647,6 +1647,9 @@ mod property_token {
                     // Reset request to pending for retry
                     request.status = BridgeOperationStatus::Pending;
                     request.signatures.clear();
+                    // Re-register in the O(1) pending lookup so duplicate-request
+                    // guard in initiate_bridge_multisig remains accurate.
+                    self.token_pending_requests.insert(request.token_id, &request_id);
                 }
                 RecoveryAction::CancelBridge => {
                     // Mark as cancelled and unlock token

--- a/meridian-contracts/contracts/property-token/src/property_token_tests.rs
+++ b/meridian-contracts/contracts/property-token/src/property_token_tests.rs
@@ -384,4 +384,130 @@
             let errors = contract.get_recent_errors(10);
             assert_eq!(errors, Vec::new());
         }
-    
+
+        // Helper: registers a property, verifies compliance, adds bob as operator,
+        // and returns the token_id.
+        fn setup_bridge_ready_token(contract: &mut PropertyToken) -> u64 {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+            let metadata = PropertyMetadata {
+                location: String::from("Bridge St"),
+                size: 1000,
+                legal_description: String::from("Bridge test property"),
+                valuation: 500000,
+                documents_url: String::from("ipfs://bridge"),
+            };
+            let token_id = contract
+                .register_property_with_token(metadata)
+                .expect("registration should succeed");
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .verify_compliance(token_id, true)
+                .expect("compliance verification should succeed");
+            contract
+                .add_bridge_operator(accounts.bob)
+                .expect("add operator should succeed");
+
+            token_id
+        }
+
+        #[ink::test]
+        fn test_duplicate_bridge_request_rejected() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+            let token_id = setup_bridge_ready_token(&mut contract);
+
+            // First request must succeed
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let first = contract.initiate_bridge_multisig(
+                token_id,
+                2,
+                accounts.bob,
+                2,
+                None,
+            );
+            assert!(first.is_ok(), "first bridge request should succeed");
+
+            // Second request for the same token must be rejected
+            let second = contract.initiate_bridge_multisig(
+                token_id,
+                2,
+                accounts.bob,
+                2,
+                None,
+            );
+            assert_eq!(second, Err(Error::DuplicateBridgeRequest));
+        }
+
+        #[ink::test]
+        fn test_pending_cleared_on_rejection() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+            let token_id = setup_bridge_ready_token(&mut contract);
+
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let request_id = contract
+                .initiate_bridge_multisig(token_id, 2, accounts.bob, 2, None)
+                .expect("initiate should succeed");
+
+            // Operator rejects
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            contract
+                .sign_bridge_request(request_id, false)
+                .expect("rejection should succeed");
+
+            // A new request for the same token must now succeed (mapping entry cleared)
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let second = contract.initiate_bridge_multisig(
+                token_id,
+                2,
+                accounts.bob,
+                2,
+                None,
+            );
+            assert!(second.is_ok(), "new request after rejection should succeed");
+        }
+
+        #[ink::test]
+        fn test_retry_bridge_restores_pending_guard() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+            let token_id = setup_bridge_ready_token(&mut contract);
+
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let request_id = contract
+                .initiate_bridge_multisig(token_id, 2, accounts.bob, 2, None)
+                .expect("initiate should succeed");
+
+            // Operator rejects -> mapping entry removed
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            contract
+                .sign_bridge_request(request_id, false)
+                .expect("rejection should succeed");
+
+            // Admin retries -> mapping entry must be restored
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .recover_failed_bridge(request_id, RecoveryAction::RetryBridge)
+                .expect("retry recovery should succeed");
+
+            // Duplicate request must now be blocked again
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let dup = contract.initiate_bridge_multisig(
+                token_id,
+                2,
+                accounts.bob,
+                2,
+                None,
+            );
+            assert_eq!(
+                dup,
+                Err(Error::DuplicateBridgeRequest),
+                "duplicate should be blocked after retry recovery"
+            );
+        }


### PR DESCRIPTION
closes #432 

<div data-testid="assistant-message" class="message_07S1Yg timelineMessage_07S1Yg  " style="color: rgb(204, 204, 204); display: flex; position: relative; flex-direction: column; align-items: flex-start; gap: 0px; padding: 8px 0px 8px 30px; user-select: text; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="root_-a7MRw" style="text-wrap: wrap; overflow-x: hidden; width: 542.344px;"><p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em;">The config uses <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">u8</code> for signatures and the default config in <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">new()</code> is <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">min_signatures_required: 2, max_signatures_required: 5</code>. Our tests pass <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">required_signatures: 2</code> which is within bounds.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;">Now let me also verify the test for <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_pending_cleared_on_rejection</code> - after rejection, the second <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">initiate_bridge_multisig</code> call for the same token should succeed. But looking at <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">initiate_bridge_multisig</code>, it checks:</p><ol style="padding-inline-start: 2em;"><li>Token owner is caller ✅ (alice still owns it since rejection doesn't transfer)</li><li>Bridge not paused ✅</li><li>Chain supported ✅ (chain 2 is in<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">vec![1, 2, 3]</code>)</li><li>Compliance verified ✅ (we verified in setup)</li><li>Signatures within range ✅</li><li>No pending request ✅ (mapping was cleared on rejection)</li></ol><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;">The test logic looks correct. Let me do a final review of the changes:</p></span></div><div data-testid="assistant-message" class="message_07S1Yg timelineMessage_07S1Yg dotSuccess_07S1Yg " style="color: rgb(204, 204, 204); display: flex; position: relative; flex-direction: column; align-items: flex-start; gap: 0px; padding: 8px 0px 8px 30px; user-select: text; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="toolUse_uq5aLg" style="width: 542.344px;"><div class="root_ZUQaOA" style="position: relative;"><summary class="toolSummary_ZUQaOA" style="list-style: none; display: -webkit-box; -webkit-line-clamp: 2; overflow: hidden; -webkit-box-orient: vertical; max-width: 100%;"><span><span class="toolNameText_ZUQaOA" style="margin-right: 4px; font-weight: 700;">Bash<span> </span></span><span class="toolNameTextSecondaryPlaintext_ZUQaOA" style="color: rgb(157, 157, 157); word-break: break-all; overflow-wrap: anywhere; flex: 1 1 0%; min-width: 0px;">Verify all token_pending_requests usage in lib.rs</span></span></summary><div class="toolBody_ZUQaOA" style="border-color: rgb(69, 69, 69); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-radius: 5px; align-items: start; max-width: 100%; margin: 8px 0px; font-size: 1em;"><div class="toolBodyGrid_ZUQaOA" style="display: grid; grid-template-columns: max-content 1fr;"><div class="toolBodyRow_ZUQaOA inputRow_F2hEIg" style="grid-column: 1 / -1; display: grid; grid-template-columns: subgrid; border-top: none; padding: 4px; position: relative;"><div class="toolBodyRowLabel_ZUQaOA" style="grid-column: 1; color: rgb(157, 157, 157); text-align: left; opacity: 0.5; font-family: monospace; padding: 4px 8px 4px 4px; font-size: 0.85em;">IN</div><div class="toolBodyRowContent_ZUQaOA" style="grid-column: 2; white-space: pre-wrap; word-break: break-word; margin: 0px; padding: 4px; mask-image: linear-gradient(rgb(24, 24, 24) 50px, rgba(0, 0, 0, 0) 60px); overflow: hidden; max-height: 60px;"><pre style="overflow: hidden; font-family: monospace; margin-block: 0px; font-size: 0.85em;">grep -n "token_pending_requests" /home/feyishola/Desktop/mydev/opensource/Stellar-soroban-contracts/meridian-contracts/contracts/property-token/src/lib.rs</pre></div><button class="copyButton_CEmTFw copyButton_F2hEIg" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-color: rgb(69, 69, 69); border-style: solid; border-width: 0.833333px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button></div><div class="toolBodyRow_ZUQaOA" style="grid-column: 1 / -1; display: grid; grid-template-columns: subgrid; border-top: 0.833333px solid rgb(69, 69, 69); padding: 4px;"><div class="toolBodyRowLabel_ZUQaOA" style="grid-column: 1; color: rgb(157, 157, 157); text-align: left; opacity: 0.5; font-family: monospace; padding: 4px 8px 4px 4px; font-size: 0.85em;">OUT</div><div class="toolBodyRowContent_ZUQaOA" style="grid-column: 2; white-space: pre-wrap; word-break: break-word; margin: 0px; padding: 4px; mask-image: linear-gradient(rgb(24, 24, 24) 50px, rgba(0, 0, 0, 0) 60px); overflow: hidden; max-height: 60px; cursor: pointer;"><div class="toolResult_uq5aLg" style="background-color: rgba(0, 0, 0, 0); white-space: pre; overflow-x: auto; box-sizing: border-box; width: 492.747px; min-width: 0px; max-width: 100%;"><pre style="overflow: hidden; font-family: monospace; margin-block: 0px; font-size: 0.85em;">82:        token_pending_requests: Mapping&lt;TokenId, u64&gt;,
158:                token_pending_requests: Mapping::default(),
1295:            self.token_pending_requests.insert(token_id, &amp;request_id);
1328:                    self.token_pending_requests.remove(request.token_id);
1344:                self.token_pending_requests.remove(request.token_id);
1422:            self.token_pending_requests.remove(request.token_id);
1652:                    self.token_pending_requests.insert(request.token_id, &amp;request_id);
1912:            self.token_pending_requests.contains(token_id)</pre></div></div></div></div></div></div></div></div><div data-testid="assistant-message" class="message_07S1Yg timelineMessage_07S1Yg  " style="color: rgb(204, 204, 204); display: flex; position: relative; flex-direction: column; align-items: flex-start; gap: 0px; padding: 8px 0px 8px 30px; user-select: text; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="root_-a7MRw" style="text-wrap: wrap; overflow-x: hidden; width: 542.344px;"><p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em;">The mapping lifecycle is now fully consistent:</p>
Site | Action
-- | --
initiate_bridge_multisig (line 1295) | insert(token_id, request_id)
sign_bridge_request expired (line 1328) | remove(token_id)
sign_bridge_request rejected (line 1344) | remove(token_id)
execute_bridge completed (line 1422) | remove(token_id)
recover_failed_bridge RetryBridge (line 1652) | insert(token_id, request_id) ← new fix
has_pending_bridge_request (line 1912) | contains(token_id) — O(1)

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;">The changes made:</p><ol style="padding-inline-start: 2em;"><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>Bug fix in <a href="vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/meridian-contracts/contracts/property-token/src/lib.rs#L1646-L1652" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">lib.rs:1646-1652</a></strong>: <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">recover_failed_bridge</code> with <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RetryBridge</code> now re-inserts the token into <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">token_pending_requests</code> after resetting the request back to <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Pending</code>. Without this, the duplicate-request guard would return <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">false</code> for the retried token, allowing a second concurrent bridge request to be created.</p></li><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>Three new tests in <a href="vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/meridian-contracts/contracts/property-token/src/property_token_tests.rs" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252);">property_token_tests.rs</a></strong>:</p><ul style="padding-inline-start: 2em;"><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_duplicate_bridge_request_rejected</code><span> </span>— verifies a second<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">initiate_bridge_multisig</code><span> </span>for the same token returns<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DuplicateBridgeRequest</code></li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_pending_cleared_on_rejection</code><span> </span>— verifies the mapping is cleared after an operator rejection, allowing a fresh request</li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test_retry_bridge_restores_pending_guard</code><span> </span>— verifies the just-fixed<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RetryBridge</code><span> </span>path restores the guard so duplicates are blocked</li></ul></li></ol></span></div>The config uses u8 for signatures and the default config in new() is min_signatures_required: 2, max_signatures_required: 5. Our tests pass required_signatures: 2 which is within bounds.

Now let me also verify the test for test_pending_cleared_on_rejection - after rejection, the second initiate_bridge_multisig call for the same token should succeed. But looking at initiate_bridge_multisig, it checks:

Token owner is caller ✅ (alice still owns it since rejection doesn't transfer)
Bridge not paused ✅
Chain supported ✅ (chain 2 is in vec![1, 2, 3])
Compliance verified ✅ (we verified in setup)
Signatures within range ✅
No pending request ✅ (mapping was cleared on rejection)
The test logic looks correct. Let me do a final review of the changes:

Bash Verify all token_pending_requests usage in lib.rs
IN
grep -n "token_pending_requests" /home/feyishola/Desktop/mydev/opensource/Stellar-soroban-contracts/meridian-contracts/contracts/property-token/src/lib.rs

OUT
82:        token_pending_requests: Mapping<TokenId, u64>,
158:                token_pending_requests: Mapping::default(),
1295:            self.token_pending_requests.insert(token_id, &request_id);
1328:                    self.token_pending_requests.remove(request.token_id);
1344:                self.token_pending_requests.remove(request.token_id);
1422:            self.token_pending_requests.remove(request.token_id);
1652:                    self.token_pending_requests.insert(request.token_id, &request_id);
1912:            self.token_pending_requests.contains(token_id)
The mapping lifecycle is now fully consistent:

Site	Action
initiate_bridge_multisig (line 1295)	insert(token_id, request_id)
sign_bridge_request expired (line 1328)	remove(token_id)
sign_bridge_request rejected (line 1344)	remove(token_id)
execute_bridge completed (line 1422)	remove(token_id)
recover_failed_bridge RetryBridge (line 1652)	insert(token_id, request_id) ← new fix
has_pending_bridge_request (line 1912)	contains(token_id) — O(1)
The changes made:

Bug fix in [lib.rs:1646-1652](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/meridian-contracts/contracts/property-token/src/lib.rs#L1646-L1652): recover_failed_bridge with RetryBridge now re-inserts the token into token_pending_requests after resetting the request back to Pending. Without this, the duplicate-request guard would return false for the retried token, allowing a second concurrent bridge request to be created.

Three new tests in [property_token_tests.rs](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/meridian-contracts/contracts/property-token/src/property_token_tests.rs):

test_duplicate_bridge_request_rejected — verifies a second initiate_bridge_multisig for the same token returns DuplicateBridgeRequest
test_pending_cleared_on_rejection — verifies the mapping is cleared after an operator rejection, allowing a fresh request
test_retry_bridge_restores_pending_guard — verifies the just-fixed RetryBridge path restores the guard so duplicates are blocked