### PR TITLE
feat(upload): implement secure file upload with validation and multi-provider support

### DIFF
--- a/meridian-api/package-lock.json
+++ b/meridian-api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@aws-sdk/client-s3": "3.787.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.3.0",
@@ -215,6 +216,740 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.787.0.tgz",
+      "integrity": "sha512-eGLCWkN0NlntJ9yPU6OKUggVS4cFvuZJog+cFg1KD5hniLqz7Y0YRtB4uBxW212fK3XCfddgyscEOEeHaTQQTw==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-node": "3.787.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.775.0",
+        "@aws-sdk/middleware-expect-continue": "3.775.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.787.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-location-constraint": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-sdk-s3": "3.775.0",
+        "@aws-sdk/middleware-ssec": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.787.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/signature-v4-multi-region": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.787.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.787.0",
+        "@aws-sdk/xml-builder": "3.775.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/eventstream-serde-browser": "^4.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
+        "@smithy/eventstream-serde-node": "^4.0.2",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-blob-browser": "^4.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/hash-stream-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/md5-js": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.787.0.tgz",
+      "integrity": "sha512-L8R+Mh258G0DC73ktpSVrG4TT9i2vmDLecARTDR/4q5sRivdDQSL5bUp3LKcK80Bx+FRw3UETIlX6mYMLL9PJQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.787.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.787.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.787.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+      "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+      "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+      "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-stream": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.787.0.tgz",
+      "integrity": "sha512-hc2taRoDlXn2uuNuHWDJljVWYrp3r9JF1a/8XmOAZhVUNY+ImeeStylHXhXXKEA4JOjW+5PdJj0f1UDkVCHJiQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/credential-provider-env": "3.775.0",
+        "@aws-sdk/credential-provider-http": "3.775.0",
+        "@aws-sdk/credential-provider-process": "3.775.0",
+        "@aws-sdk/credential-provider-sso": "3.787.0",
+        "@aws-sdk/credential-provider-web-identity": "3.787.0",
+        "@aws-sdk/nested-clients": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.787.0.tgz",
+      "integrity": "sha512-JioVi44B1vDMaK2CdzqimwvJD3uzvzbQhaEWXsGMBcMcNHajXAXf08EF50JG3ZhLrhhUsT1ObXpbTaPINOhh+g==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.775.0",
+        "@aws-sdk/credential-provider-http": "3.775.0",
+        "@aws-sdk/credential-provider-ini": "3.787.0",
+        "@aws-sdk/credential-provider-process": "3.775.0",
+        "@aws-sdk/credential-provider-sso": "3.787.0",
+        "@aws-sdk/credential-provider-web-identity": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/credential-provider-imds": "^4.0.2",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+      "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.787.0.tgz",
+      "integrity": "sha512-fHc08bsvwm4+dEMEQKnQ7c1irEQmmxbgS+Fq41y09pPvPh31nAhoMcjBSTWAaPHvvsRbTYvmP4Mf12ZGr8/nfg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.787.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/token-providers": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.787.0.tgz",
+      "integrity": "sha512-SobmCwNbk6TfEsF283mZPQEI5vV2j6eY5tOCj8Er4Lzraxu9fBPADV+Bib2A8F6jlB1lMPJzOuDCbEasSt/RIw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/nested-clients": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.775.0.tgz",
+      "integrity": "sha512-qogMIpVChDYr4xiUNC19/RDSw/sKoHkAhouS6Skxiy6s27HBhow1L3Z1qVYXuBmOZGSWPU0xiyZCvOyWrv9s+Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-arn-parser": "3.723.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.775.0.tgz",
+      "integrity": "sha512-Apd3owkIeUW5dnk3au9np2IdW2N0zc9NjTjHiH+Mx3zqwSrc+m+ANgJVgk9mnQjMzU/vb7VuxJ0eqdEbp5gYsg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.787.0.tgz",
+      "integrity": "sha512-X71qEwWoixFmwowWzlPoZUR3u1CWJ7iAzU0EzIxqmPhQpQJLFmdL1+SRjqATynDPZQzLs1a5HBtPT++EnZ+Quw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+      "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.775.0.tgz",
+      "integrity": "sha512-8TMXEHZXZTFTckQLyBT5aEI8fX11HZcwZseRifvBKKpj0RZDk4F0EEYGxeNSPpUQ7n+PRWyfAEnnZNRdAj/1NQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+      "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+      "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.775.0.tgz",
+      "integrity": "sha512-zsvcu7cWB28JJ60gVvjxPCI7ZU7jWGcpNACPiZGyVtjYXwcxyhXbYEVDSWKsSA6ERpz9XrpLYod8INQWfW3ECg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-arn-parser": "3.723.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.0.2",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-stream": "^4.2.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.775.0.tgz",
+      "integrity": "sha512-Iw1RHD8vfAWWPzBBIKaojO4GAvQkHOYIpKdAfis/EUSUmSa79QsnXnRqsdcE0mCB0Ylj23yi+ah4/0wh9FsekA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.787.0.tgz",
+      "integrity": "sha512-Lnfj8SmPLYtrDFthNIaNj66zZsBCam+E4XiUDr55DIHTGstH6qZ/q6vg0GfbukxwSmUcGMwSR4Qbn8rb8yd77g==",
+      "dependencies": {
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.787.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.787.0.tgz",
+      "integrity": "sha512-xk03q1xpKNHgbuo+trEf1dFrI239kuMmjKKsqLEsHlAZbuFq4yRGMlHBrVMnKYOPBhVFDS/VineM991XI52fKg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.775.0",
+        "@aws-sdk/middleware-host-header": "3.775.0",
+        "@aws-sdk/middleware-logger": "3.775.0",
+        "@aws-sdk/middleware-recursion-detection": "3.775.0",
+        "@aws-sdk/middleware-user-agent": "3.787.0",
+        "@aws-sdk/region-config-resolver": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@aws-sdk/util-endpoints": "3.787.0",
+        "@aws-sdk/util-user-agent-browser": "3.775.0",
+        "@aws-sdk/util-user-agent-node": "3.787.0",
+        "@smithy/config-resolver": "^4.1.0",
+        "@smithy/core": "^3.2.0",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/middleware-retry": "^4.1.0",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.8",
+        "@smithy/util-defaults-mode-node": "^4.0.8",
+        "@smithy/util-endpoints": "^3.0.2",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+      "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.775.0.tgz",
+      "integrity": "sha512-cnGk8GDfTMJ8p7+qSk92QlIk2bmTmFJqhYxcXZ9PysjZtx0xmfCMxnG3Hjy1oU2mt5boPCVSOptqtWixayM17g==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.775.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.787.0.tgz",
+      "integrity": "sha512-d7/NIqxq308Zg0RPMNrmn0QvzniL4Hx8Qdwzr6YZWLYAbUSvZYS2ppLR3BFWSkV6SsTJUx8BuDaj3P8vttkrog==",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/shared-ini-file-loader": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+      "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.723.0.tgz",
+      "integrity": "sha512-ZhEfvUwNliOQROcAk34WJWVYTlTa4694kSVhDSjW6lE1bMataPnIN8A0ycukEzBXmd8ZSoBcQLn6lKGl7XIJ5w==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.787.0.tgz",
+      "integrity": "sha512-fd3zkiOkwnbdbN0Xp9TsP5SWrmv0SpT70YEdbb8wAj2DWQwiCmFszaSs+YCvhoCdmlR3Wl9Spu0pGpSAGKeYvQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-endpoints": "^3.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+      "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/types": "^4.2.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.787.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.787.0.tgz",
+      "integrity": "sha512-mG7Lz8ydfG4SF9e8WSXiPQ/Lsn3n8A5B5jtPROidafi06I3ckV2WxyMLdwG14m919NoS6IOfWHyRGSqWIwbVKA==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.787.0",
+        "@aws-sdk/types": "3.775.0",
+        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.775.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.775.0.tgz",
+      "integrity": "sha512-b9NGO6FKJeLGYnV7Z1yvcP1TNU4dkD5jNsLWOF1/sygZoASaQhNOlaiJ/1OH331YQ1R1oWk38nBb0frsYkDsOQ==",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2664,6 +3399,502 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.6.1.tgz",
+      "integrity": "sha512-VgMsljDnHwHjJQAvLmkaOc1d3On5/2Zh1/21++9FFhYS9YKMnGgolJF73EU3QfFPSzK5jTTFlGk3em0hiRKtwg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+      "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
+      "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.4.1.tgz",
+      "integrity": "sha512-u1wI6ilZtur9uBmfndaccTMOvzdszEhmnG9CmnB7ws0omdYxkpRvO112UZdDxo7Ab8TIbrRKtITMua5ntBCJ9g==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.5.1.tgz",
+      "integrity": "sha512-tnPdkY8zM98wboQFRoog1XV/Yjv7Zz61cDJxciHqyHwuCLo/jhkRCUwnicpmUJ6EzGys0FkwveHZNkIO7lcOpQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.4.1.tgz",
+      "integrity": "sha512-h/4/rKk5d2w+vRBTbVzOvu4kxq+zNmtuGIlcI8hpE/yhsR2Ky+4YZRVU1JLx/sp+Ee9eoG8/hRjvAErcQOCQoQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+      "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.4.1.tgz",
+      "integrity": "sha512-5pDuFvbCim3Er0SDLJWiR9P9r73ranu/FK3ZV/i3/mIVYi+P10h/rcaS51Kgh+1TKQbZSCnsGJkbJJnM27T9bg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.4.1.tgz",
+      "integrity": "sha512-hFez+gkhSHuBoo3t/xTNp+rKx8Hd5VaJPBexBtVkyA/XqMgOUm1eNY00nIEtUDMTjdRbfJASIWXbY2bGpjRYcA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.4.1.tgz",
+      "integrity": "sha512-5mIF0Qnpkokf8qN1LH2+cI09TQOvFedvNNK/eRhfhbC5E9zxtyTPSprWQFI4Kb6tRp+iBsllO/aaxeDjgASREQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.4.1.tgz",
+      "integrity": "sha512-eMmXNUign1HaUU5KGcnOWMeTt21oeuvamPaP5ZwM6VeyuHeoBKOSGOW3DVnJbBX79Xd4/yeLcbZKrIS3HpCDMg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.4.1.tgz",
+      "integrity": "sha512-GCgtCtlrm686i1Zc2MCVSxLX9e1D9l+QA9N6LkDQqx+L0rn6uJcRc5wIfw1vt1X2XiX5zXA0gkd0usxbNFuBPg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.4.1.tgz",
+      "integrity": "sha512-6xEY7LhQYgj0mEKUa4TNNkPaF/EwY4Z7OM6lmOwOqaykK3BRMqabHVf0wk+C1e1JYTmx6rYVxz+8JWxbLErytA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.4.1.tgz",
+      "integrity": "sha512-3WPxBy1eRXsVnXh7twWJWCkoV7cEjPwBbYaJ0RuIVFP/LjcKkAbLuWOtpv2j770yPgA+Jyf6y7z3QMEICVfxrQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.6.1.tgz",
+      "integrity": "sha512-TgyNn9dd8oC87+9M5Iarpf0Nr8UTtlJW0FwEMtZHc6CbhD2NZDv9kYapnnLPmhdIOvX/XDatn26Cl9UhdZJsNQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.7.1.tgz",
+      "integrity": "sha512-PYBrqSyaoW0f5aU7tFzJhrm0F0t3zIrEhwF69cIHSkDRlcP90ueF/Atm0npgRk2xSvcTYzfbs1kCT8Fw/SS+3w==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.4.1.tgz",
+      "integrity": "sha512-WoibOTvoqWrHuahqyHx677qPKDqB/Xp4pW2793kAHgh/WD1fAdLp6DrNfvXViUKxJWb/W5QNAv3R9nYcrQnbuw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.4.1.tgz",
+      "integrity": "sha512-QKi4auCXmRAKOlu9YRF39Ni4JynmwoHvIwWXZS+trP/Zm8r7Z5KmaiW7R3CJERfMcrSzqMHjadzGugUuzUnZKQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.5.1.tgz",
+      "integrity": "sha512-0eZmif/bZe3dbrazG24BmormVJ7E0yoK9IN4wcNopYLM0MNElhgd3QfPyLeuLWWi0HR+MYu3JBy0LMzAZ8u2aQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+      "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.4.1.tgz",
+      "integrity": "sha512-/Y/6FRAwRNIspg/OSkrnqOKoZ8AbzB4W5Wviac9QFKdAnpqK65oYPgLyNtRJ29Xr29X7TdXToZ8U3Yo+ly0ifA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.5.1.tgz",
+      "integrity": "sha512-GRQofBqr/pPNjR04mU0JjdjsbV8F33KCxSHMFXBb2mWJXxyEalNe814Y4cFd4Efd5tNucaOc31L3/8wXlymjfg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.6.1.tgz",
+      "integrity": "sha512-siGDpISZcrCQQaOLN6UtBO/k98XigaU5MLf1RGYRXMP1uwz9JuL9Go21SPHm6YEJbFGYloConRuT2pDrgcrePA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+      "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.14.1.tgz",
+      "integrity": "sha512-/GsNFh1enYQB4w3x1+ZHR3IFtEya3UlcyF/8+0GUX6qObxPsm8uA4EHzopmcO5Z6DjxLwjAOco+1wwCr9mis0A==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.4.1.tgz",
+      "integrity": "sha512-nuY/KEW0mHOS1ZA3NN4xjSOR5TxIwnUSbvSh39KUhBGQ3xKkaf89ftnvw0yI+Ekr3GGobzO4Elj9t+4POP8iDg==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.5.1.tgz",
+      "integrity": "sha512-B4bqm9OpfcKda2sppILh7MFXNBS6IkcCYJAiFzgUWbC75luhBvgfHd5eMvEFpTfhDtpUQAPQrcCX0twMNeExmw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.4.1.tgz",
+      "integrity": "sha512-eOowAQTjfrhd0Uci2vPppHx4SMdWD8wouzniFd8AOU0HCp6bmEsRZd3pEDJHhXWZ2jh7erz4+qpY+tVJabRHKA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.4.1.tgz",
+      "integrity": "sha512-eEDHEciyZ3qXYY2rNBWFApS3iaTq5etqkUju4p5CO1ofF7cGFeH36yM3YlC7o1PHwMN4qvq5jiU+UkG4kzaHGw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.4.1.tgz",
+      "integrity": "sha512-qB7jd2r/+kb+e1dzdg+SSMJE/q43ICtvnI+KiqvECluTFWpdfOa8BxmKlZM7H5k5uuGeJZj09IuvAcPljoMKzQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.5.1.tgz",
+      "integrity": "sha512-Q19s6CWcliyjkGesjKikzDuUUu8/a6ijKM8x9S84WfUgVFimcX2WM9gfZIXbdrD93YD7AFklX4ZsPa/H0DKSNw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.4.1.tgz",
+      "integrity": "sha512-I6LP1stNp6TkSjHWw3s5hXDDYUOxML5hBWAP6jshMYcsufZiLErpD5rc0657IWTMbYocs2OjRAjQJ8KMt4OpiQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.6.1.tgz",
+      "integrity": "sha512-7/p7K1wgOrwA+NJDk7ca+eGWs9G2xQqhcZhFa0T7inEOav31ZmGTWgPIR382ydh5TsBE8K/kR0sAss1+PlBqrA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.4.1.tgz",
+      "integrity": "sha512-UGV7Kg5WwiJaUoYQcS6VPe/qa/BRYnTLx5drtkCExohCxnJ0IKCtXe/HZUig8NswFjXf4xmsg4lAVRQHppB3fA==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.5.1.tgz",
+      "integrity": "sha512-SQJhb5j3Btnqvh4lYdWbVH5uuoJN1kdn+UI/ehsEwhV7kHMOp4DwTBxFpUiMIgviiZsIrOk0YyI9R42yBZw90A==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.7.1.tgz",
+      "integrity": "sha512-PxEh26CfAkeY9et6ak8gvu+23QdXyBwvf8bnkltD2cei9bMPT9rx5wSBWv1+mTuFtZzdpcksvQfdT0JA8IFcXQ==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.5.1.tgz",
+      "integrity": "sha512-pqI0LUxwqkjMYCyIm8A5MrTYpfS3WTD9210QL5MW8m1KQ83MWFR+rjuy1eBnttpZwFqQ9DWnEwr8TZsq9wVTbw==",
+      "dependencies": {
+        "@smithy/core": "^3.25.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -4177,6 +5408,11 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -6396,6 +7632,27 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6832,6 +8089,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12991,6 +14249,17 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/strtok3": {
       "version": "10.3.5",

--- a/meridian-api/package.json
+++ b/meridian-api/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "3.787.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",

--- a/meridian-api/src/upload/config/upload.config.ts
+++ b/meridian-api/src/upload/config/upload.config.ts
@@ -1,0 +1,23 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * Upload configuration namespace.
+ *
+ * Env vars consumed:
+ *   STORAGE_PROVIDER   – 'local' (default) | 's3'
+ *   UPLOAD_MAX_SIZE_MB – maximum file size in MB (default: 5)
+ *   UPLOAD_S3_BUCKET   – S3 bucket name (required when STORAGE_PROVIDER=s3)
+ *   UPLOAD_S3_REGION   – AWS region       (required when STORAGE_PROVIDER=s3)
+ *   UPLOAD_S3_ACCESS_KEY_ID     – AWS access key (optional; falls back to SDK default chain)
+ *   UPLOAD_S3_SECRET_ACCESS_KEY – AWS secret key (optional; falls back to SDK default chain)
+ */
+export default registerAs('upload', () => ({
+  storageProvider: process.env.STORAGE_PROVIDER || 'local',
+  maxFileSizeMb: Number(process.env.UPLOAD_MAX_SIZE_MB) || 5,
+  s3: {
+    bucket: process.env.UPLOAD_S3_BUCKET || '',
+    region: process.env.UPLOAD_S3_REGION || '',
+    accessKeyId: process.env.UPLOAD_S3_ACCESS_KEY_ID || '',
+    secretAccessKey: process.env.UPLOAD_S3_SECRET_ACCESS_KEY || '',
+  },
+}));

--- a/meridian-api/src/upload/providers/local-storage.provider.spec.ts
+++ b/meridian-api/src/upload/providers/local-storage.provider.spec.ts
@@ -1,0 +1,95 @@
+import { LocalStorageProvider } from './local-storage.provider';
+import * as fs from 'fs';
+
+describe('LocalStorageProvider', () => {
+  let provider: LocalStorageProvider;
+
+  beforeEach(() => {
+    provider = new LocalStorageProvider();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function makeFile(
+    originalname: string,
+    overrides?: Partial<Express.Multer.File>,
+  ): Express.Multer.File {
+    return {
+      originalname,
+      mimetype: 'image/png',
+      buffer: Buffer.from('fake image content'),
+      size: 18,
+      ...overrides,
+    } as Express.Multer.File;
+  }
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+
+  it('returns a /uploads/ path after a successful write', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+    const result = await provider.uploadFile(makeFile('photo.png'));
+    expect(result).toMatch(/^\/uploads\/\d+-photo\.png$/);
+  });
+
+  it('creates the uploads directory when it does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mkdirSpy = jest
+      .spyOn(fs, 'mkdirSync')
+      .mockImplementation(() => undefined);
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+    await provider.uploadFile(makeFile('photo.png'));
+    expect(mkdirSpy).toHaveBeenCalledWith(
+      expect.stringContaining('uploads'),
+      expect.objectContaining({ recursive: true, mode: 0o755 }),
+    );
+  });
+
+  it('sanitizes path traversal sequences in the filename', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+    const result = await provider.uploadFile(makeFile('../../unsafe.png'));
+    expect(result).not.toContain('..');
+    expect(result).not.toContain('/uploads/../');
+  });
+
+  it('sanitizes special characters from the filename', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+    const result = await provider.uploadFile(
+      makeFile('../../unsafe-name#$.png'),
+    );
+    expect(result).not.toContain('#');
+    expect(result).not.toContain('$');
+    expect(result).not.toContain('..');
+    expect(result).toMatch(/\.png$/);
+  });
+
+  it('strips double extensions from the filename', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+
+    const result = await provider.uploadFile(makeFile('malware.php.png'));
+    expect(result).toMatch(/\.png$/);
+    expect(result).not.toContain('.php.');
+  });
+
+  it('wraps unexpected write errors in InternalServerErrorException', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest
+      .spyOn(fs.promises, 'writeFile')
+      .mockRejectedValue(new Error('disk full'));
+
+    await expect(provider.uploadFile(makeFile('test.png'))).rejects.toThrow(
+      'Local file storage failed: disk full',
+    );
+  });
+});

--- a/meridian-api/src/upload/providers/local-storage.provider.ts
+++ b/meridian-api/src/upload/providers/local-storage.provider.ts
@@ -1,0 +1,52 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { StorageProvider } from '../storage-provider.interface';
+import { sanitizeFilename } from '../utils/sanitize-filename';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Stores uploaded files on the local filesystem under <cwd>/uploads/.
+ *
+ * Security measures:
+ *  - Filenames are sanitized via sanitizeFilename() (path traversal, double
+ *    extensions, special characters).
+ *  - The resolved destination path is verified to remain inside the uploads
+ *    directory before writing (belt-and-suspenders path traversal check).
+ *  - The uploads directory is created with mode 0o755 if it does not yet exist.
+ */
+@Injectable()
+export class LocalStorageProvider implements StorageProvider {
+  async uploadFile(file: Express.Multer.File): Promise<string> {
+    try {
+      const uploadDir = path.join(process.cwd(), 'uploads');
+
+      // Ensure directory exists with safe permissions (not world-writable).
+      if (!fs.existsSync(uploadDir)) {
+        fs.mkdirSync(uploadDir, { recursive: true, mode: 0o755 });
+      }
+
+      const uniqueName = sanitizeFilename(file.originalname);
+      const filePath = path.join(uploadDir, uniqueName);
+
+      // Final path-traversal guard: resolved path must stay inside uploadDir.
+      const resolvedPath = path.resolve(filePath);
+      const resolvedUploadDir = path.resolve(uploadDir);
+
+      if (!resolvedPath.startsWith(resolvedUploadDir + path.sep) &&
+          resolvedPath !== resolvedUploadDir) {
+        throw new InternalServerErrorException(
+          'Invalid file path detected (potential path traversal)',
+        );
+      }
+
+      await fs.promises.writeFile(filePath, file.buffer);
+
+      return `/uploads/${uniqueName}`;
+    } catch (error) {
+      if (error instanceof InternalServerErrorException) throw error;
+      throw new InternalServerErrorException(
+        `Local file storage failed: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/meridian-api/src/upload/providers/s3-storage.provider.spec.ts
+++ b/meridian-api/src/upload/providers/s3-storage.provider.spec.ts
@@ -1,0 +1,111 @@
+import { S3StorageProvider } from './s3-storage.provider';
+import { ConfigService } from '@nestjs/config';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+// Mock the entire AWS SDK S3 client so tests run without real credentials.
+jest.mock('@aws-sdk/client-s3', () => {
+  const sendMock = jest.fn().mockResolvedValue({});
+  return {
+    S3Client: jest.fn().mockImplementation(() => ({ send: sendMock })),
+    PutObjectCommand: jest.fn().mockImplementation((input) => input),
+    __sendMock: sendMock,
+  };
+});
+
+function makeConfigService(overrides: Record<string, string> = {}): ConfigService {
+  return {
+    get: jest.fn((key: string) => {
+      const defaults: Record<string, string> = {
+        UPLOAD_S3_BUCKET: 'my-test-bucket',
+        UPLOAD_S3_REGION: 'us-west-2',
+        UPLOAD_S3_ACCESS_KEY_ID: '',
+        UPLOAD_S3_SECRET_ACCESS_KEY: '',
+      };
+      return overrides[key] ?? defaults[key] ?? null;
+    }),
+  } as unknown as ConfigService;
+}
+
+function makeFile(originalname: string): Express.Multer.File {
+  return {
+    originalname,
+    mimetype: 'image/png',
+    buffer: Buffer.from('fake png data'),
+    size: 13,
+  } as Express.Multer.File;
+}
+
+describe('S3StorageProvider', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    const provider = new S3StorageProvider(makeConfigService());
+    expect(provider).toBeDefined();
+  });
+
+  it('returns a correctly formatted S3 URL with a sanitized filename', async () => {
+    const provider = new S3StorageProvider(makeConfigService());
+    const result = await provider.uploadFile(makeFile('hello world!.png'));
+
+    expect(result).toMatch(
+      /^https:\/\/my-test-bucket\.s3\.us-west-2\.amazonaws\.com\/.+\.png$/,
+    );
+    expect(result).not.toContain(' ');
+    expect(result).not.toContain('!');
+  });
+
+  it('calls PutObjectCommand with correct Bucket, Key, Body, and ContentType', async () => {
+    const provider = new S3StorageProvider(makeConfigService());
+    await provider.uploadFile(makeFile('document.pdf'));
+
+    expect(PutObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: 'my-test-bucket',
+        ContentType: 'image/png',
+        Body: expect.any(Buffer),
+        Key: expect.stringMatching(/\.pdf$/),
+      }),
+    );
+  });
+
+  it('throws InternalServerErrorException when bucket is missing', async () => {
+    const provider = new S3StorageProvider(
+      makeConfigService({ UPLOAD_S3_BUCKET: '', UPLOAD_S3_REGION: 'us-east-1' }),
+    );
+    await expect(provider.uploadFile(makeFile('test.png'))).rejects.toThrow(
+      'S3 storage is not properly configured (missing bucket or region)',
+    );
+  });
+
+  it('throws InternalServerErrorException when region is missing', async () => {
+    const provider = new S3StorageProvider(
+      makeConfigService({ UPLOAD_S3_BUCKET: 'bucket', UPLOAD_S3_REGION: '' }),
+    );
+    await expect(provider.uploadFile(makeFile('test.png'))).rejects.toThrow(
+      'S3 storage is not properly configured (missing bucket or region)',
+    );
+  });
+
+  it('wraps SDK errors in InternalServerErrorException', async () => {
+    // Make the mocked send() throw on the next call.
+    const { __sendMock } = jest.requireMock('@aws-sdk/client-s3') as {
+      __sendMock: jest.Mock;
+    };
+    __sendMock.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const provider = new S3StorageProvider(makeConfigService());
+    await expect(provider.uploadFile(makeFile('test.png'))).rejects.toThrow(
+      'S3 file storage failed: Network timeout',
+    );
+  });
+
+  it('strips double extensions from the S3 key', async () => {
+    const provider = new S3StorageProvider(makeConfigService());
+    const result = await provider.uploadFile(makeFile('malware.php.png'));
+
+    expect(result).toMatch(/\.png$/);
+    expect(result).not.toContain('.php.');
+  });
+});

--- a/meridian-api/src/upload/providers/s3-storage.provider.ts
+++ b/meridian-api/src/upload/providers/s3-storage.provider.ts
@@ -1,0 +1,82 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  PutObjectCommandInput,
+} from '@aws-sdk/client-s3';
+import { StorageProvider } from '../storage-provider.interface';
+import { sanitizeFilename } from '../utils/sanitize-filename';
+
+/**
+ * Uploads files to an S3-compatible bucket.
+ *
+ * Required env vars:
+ *   UPLOAD_S3_BUCKET   – target bucket name
+ *   UPLOAD_S3_REGION   – AWS region
+ *
+ * Optional env vars (fall back to the AWS SDK default credential chain):
+ *   UPLOAD_S3_ACCESS_KEY_ID
+ *   UPLOAD_S3_SECRET_ACCESS_KEY
+ *
+ * The provider is compatible with any S3-compatible service (MinIO, Cloudflare
+ * R2, etc.) as long as the standard AWS SDK credential/config env vars are set.
+ */
+@Injectable()
+export class S3StorageProvider implements StorageProvider {
+  private readonly s3Client: S3Client;
+  private readonly bucket: string;
+  private readonly region: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.bucket = this.configService.get<string>('UPLOAD_S3_BUCKET') ?? '';
+    this.region = this.configService.get<string>('UPLOAD_S3_REGION') ?? '';
+
+    const accessKeyId =
+      this.configService.get<string>('UPLOAD_S3_ACCESS_KEY_ID') ?? '';
+    const secretAccessKey =
+      this.configService.get<string>('UPLOAD_S3_SECRET_ACCESS_KEY') ?? '';
+
+    const clientConfig: ConstructorParameters<typeof S3Client>[0] = {
+      region: this.region || 'us-east-1',
+    };
+
+    // Only supply explicit credentials when both values are present; otherwise
+    // fall back to the SDK's default credential provider chain (env vars, ~/.aws
+    // config, IAM role, etc.).
+    if (accessKeyId && secretAccessKey) {
+      clientConfig.credentials = { accessKeyId, secretAccessKey };
+    }
+
+    this.s3Client = new S3Client(clientConfig);
+  }
+
+  async uploadFile(file: Express.Multer.File): Promise<string> {
+    if (!this.bucket || !this.region) {
+      throw new InternalServerErrorException(
+        'S3 storage is not properly configured (missing bucket or region)',
+      );
+    }
+
+    try {
+      const key = sanitizeFilename(file.originalname);
+
+      const params: PutObjectCommandInput = {
+        Bucket: this.bucket,
+        Key: key,
+        Body: file.buffer,
+        ContentType: file.mimetype,
+        // Do NOT set ACL here — bucket policies are the recommended approach.
+      };
+
+      await this.s3Client.send(new PutObjectCommand(params));
+
+      return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+    } catch (error) {
+      if (error instanceof InternalServerErrorException) throw error;
+      throw new InternalServerErrorException(
+        `S3 file storage failed: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/meridian-api/src/upload/storage-provider.interface.ts
+++ b/meridian-api/src/upload/storage-provider.interface.ts
@@ -1,0 +1,5 @@
+import { Express } from 'express';
+
+export interface StorageProvider {
+  uploadFile(file: Express.Multer.File): Promise<string>;
+}

--- a/meridian-api/src/upload/upload.controller.spec.ts
+++ b/meridian-api/src/upload/upload.controller.spec.ts
@@ -1,12 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { UploadController } from './upload.controller';
+import { UploadService } from './upload.service';
+
+// Valid PNG magic bytes
+const PNG_MAGIC = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+function makeFile(overrides?: Partial<Express.Multer.File>): Express.Multer.File {
+  return {
+    originalname: 'test.png',
+    mimetype: 'image/png',
+    buffer: PNG_MAGIC,
+    size: PNG_MAGIC.length,
+    ...overrides,
+  } as Express.Multer.File;
+}
 
 describe('UploadController', () => {
   let controller: UploadController;
+  let service: jest.Mocked<Pick<UploadService, 'uploadFile'>>;
 
   beforeEach(async () => {
+    service = {
+      uploadFile: jest.fn().mockResolvedValue({
+        url: '/uploads/test.png',
+        originalName: 'test.png',
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UploadController],
+      providers: [{ provide: UploadService, useValue: service }],
     }).compile();
 
     controller = module.get<UploadController>(UploadController);
@@ -14,5 +40,33 @@ describe('UploadController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('delegates to uploadService.uploadFile and returns the result', async () => {
+    const file = makeFile();
+    const result = await controller.uploadFile(file);
+
+    expect(service.uploadFile).toHaveBeenCalledWith(file);
+    expect(result).toEqual({ url: '/uploads/test.png', originalName: 'test.png' });
+  });
+
+  it('propagates BadRequestException from the service', async () => {
+    service.uploadFile.mockRejectedValueOnce(
+      new BadRequestException('File type "application/javascript" is not allowed'),
+    );
+
+    await expect(controller.uploadFile(makeFile())).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('propagates BadRequestException for magic byte mismatch', async () => {
+    service.uploadFile.mockRejectedValueOnce(
+      new BadRequestException('File content does not match its declared type'),
+    );
+
+    await expect(controller.uploadFile(makeFile())).rejects.toThrow(
+      BadRequestException,
+    );
   });
 });

--- a/meridian-api/src/upload/upload.controller.ts
+++ b/meridian-api/src/upload/upload.controller.ts
@@ -3,6 +3,9 @@ import {
   Post,
   UploadedFile,
   UseInterceptors,
+  ParseFilePipe,
+  MaxFileSizeValidator,
+  FileTypeValidator,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -12,16 +15,19 @@ import {
   ApiConsumes,
   ApiBody,
 } from '@nestjs/swagger';
+import { UploadService, MAX_FILE_SIZE } from './upload.service';
 
 @ApiTags('Upload')
 @Controller('upload')
 export class UploadController {
+  constructor(private readonly uploadService: UploadService) {}
+
   @Post()
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Upload a file asset' })
   @ApiResponse({ status: 201, description: 'File successfully uploaded' })
-  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 400, description: 'Bad request – invalid file type, size, or content' })
   @ApiBody({
     schema: {
       type: 'object',
@@ -29,11 +35,30 @@ export class UploadController {
         file: {
           type: 'string',
           format: 'binary',
+          description: 'Allowed types: JPEG, PNG, GIF, PDF. Max size: 5 MB.',
         },
       },
     },
   })
-  uploadFile(@UploadedFile() file: Express.Multer.File) {
-    console.log(file);
+  async uploadFile(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          // Layer 1 – size guard (fast-fail before reading the whole buffer).
+          new MaxFileSizeValidator({
+            maxSize: MAX_FILE_SIZE,
+            message: 'File size exceeds the 5 MB limit',
+          }),
+          // Layer 2 – MIME-type guard (header-level).
+          // Deep content validation (magic bytes) is done inside UploadService.
+          new FileTypeValidator({
+            fileType: /^(image\/jpeg|image\/png|image\/gif|application\/pdf)$/,
+          }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+  ) {
+    return this.uploadService.uploadFile(file);
   }
 }

--- a/meridian-api/src/upload/upload.module.ts
+++ b/meridian-api/src/upload/upload.module.ts
@@ -1,9 +1,32 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UploadController } from './upload.controller';
 import { UploadService } from './upload.service';
+import { LocalStorageProvider } from './providers/local-storage.provider';
+import { S3StorageProvider } from './providers/s3-storage.provider';
+import uploadConfig from './config/upload.config';
 
 @Module({
+  imports: [ConfigModule.forFeature(uploadConfig)],
   controllers: [UploadController],
-  providers: [UploadService],
+  providers: [
+    UploadService,
+    LocalStorageProvider,
+    S3StorageProvider,
+    {
+      provide: 'STORAGE_PROVIDER',
+      inject: [ConfigService, LocalStorageProvider, S3StorageProvider],
+      useFactory: (
+        configService: ConfigService,
+        local: LocalStorageProvider,
+        s3: S3StorageProvider,
+      ) => {
+        const providerType =
+          configService.get<string>('STORAGE_PROVIDER') || 'local';
+        return providerType.toLowerCase() === 's3' ? s3 : local;
+      },
+    },
+  ],
+  exports: [UploadService],
 })
 export class UploadModule {}

--- a/meridian-api/src/upload/upload.service.spec.ts
+++ b/meridian-api/src/upload/upload.service.spec.ts
@@ -1,18 +1,147 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { UploadService } from './upload.service';
+import { BadRequestException } from '@nestjs/common';
+import { UploadService, ALLOWED_MIME_TYPES, MAX_FILE_SIZE } from './upload.service';
+import { StorageProvider } from './storage-provider.interface';
+
+// Valid magic-byte headers for each allowed type
+const MAGIC: Record<string, Buffer> = {
+  'image/jpeg': Buffer.from([0xff, 0xd8, 0xff, 0x00]),
+  'image/png': Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  'image/gif': Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00]),
+  'application/pdf': Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d]),
+};
+
+function makeFile(
+  overrides: Partial<Express.Multer.File> & { mimetype: string },
+): Express.Multer.File {
+  const magic = MAGIC[overrides.mimetype] ?? Buffer.alloc(0);
+  return {
+    originalname: 'test.png',
+    size: magic.length,
+    buffer: magic,
+    ...overrides,
+  } as Express.Multer.File;
+}
 
 describe('UploadService', () => {
   let service: UploadService;
+  let storageProvider: jest.Mocked<StorageProvider>;
 
   beforeEach(async () => {
+    storageProvider = {
+      uploadFile: jest.fn().mockResolvedValue('/uploads/test.png'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UploadService],
+      providers: [
+        UploadService,
+        { provide: 'STORAGE_PROVIDER', useValue: storageProvider },
+      ],
     }).compile();
 
     service = module.get<UploadService>(UploadService);
   });
 
+  // ── happy path ─────────────────────────────────────────────────────────────
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it.each(ALLOWED_MIME_TYPES)(
+    'accepts valid %s files and delegates to the storage provider',
+    async (mime) => {
+      const file = makeFile({ mimetype: mime, originalname: 'file' });
+      storageProvider.uploadFile.mockResolvedValueOnce('/uploads/file');
+
+      const result = await service.uploadFile(file);
+      expect(storageProvider.uploadFile).toHaveBeenCalledWith(file);
+      expect(result).toEqual({ url: '/uploads/file', originalName: 'file' });
+    },
+  );
+
+  // ── missing file ────────────────────────────────────────────────────────────
+
+  it('throws BadRequestException when file is undefined', async () => {
+    await expect(
+      service.uploadFile(undefined as unknown as Express.Multer.File),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ── MIME-type validation ────────────────────────────────────────────────────
+
+  it('throws BadRequestException for a disallowed MIME type', async () => {
+    const file = makeFile({
+      mimetype: 'application/javascript',
+      buffer: Buffer.from('alert(1)'),
+    });
+
+    await expect(service.uploadFile(file)).rejects.toThrow(BadRequestException);
+    await expect(service.uploadFile(file)).rejects.toThrow(
+      /not allowed/i,
+    );
+  });
+
+  it('throws BadRequestException for application/octet-stream', async () => {
+    const file = makeFile({
+      mimetype: 'application/octet-stream',
+      buffer: Buffer.from([0x4d, 0x5a]), // PE header (Windows exe)
+    });
+    await expect(service.uploadFile(file)).rejects.toThrow(BadRequestException);
+  });
+
+  // ── magic-byte validation ───────────────────────────────────────────────────
+
+  it('throws BadRequestException when buffer does not match declared MIME (jpeg spoofed as png)', async () => {
+    const file = makeFile({
+      mimetype: 'image/png',
+      // JPEG magic bytes, not PNG
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]),
+    });
+    await expect(service.uploadFile(file)).rejects.toThrow(BadRequestException);
+    await expect(service.uploadFile(file)).rejects.toThrow(
+      /magic byte/i,
+    );
+  });
+
+  it('throws BadRequestException when an exe is disguised as a PDF', async () => {
+    const file = makeFile({
+      mimetype: 'application/pdf',
+      originalname: 'invoice.pdf',
+      // MZ (Windows executable) magic bytes instead of %PDF
+      buffer: Buffer.from([0x4d, 0x5a, 0x90, 0x00]),
+    });
+    await expect(service.uploadFile(file)).rejects.toThrow(BadRequestException);
+  });
+
+  it('accepts GIF87a magic bytes for image/gif', async () => {
+    const gif87aBuffer = Buffer.from([
+      0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x01, 0x00,
+    ]);
+    const file = makeFile({
+      mimetype: 'image/gif',
+      originalname: 'anim.gif',
+      buffer: gif87aBuffer,
+    });
+    storageProvider.uploadFile.mockResolvedValueOnce('/uploads/anim.gif');
+    const result = await service.uploadFile(file);
+    expect(result.url).toBe('/uploads/anim.gif');
+  });
+
+  // ── size constant ───────────────────────────────────────────────────────────
+
+  it('exports MAX_FILE_SIZE of 5 MB', () => {
+    expect(MAX_FILE_SIZE).toBe(5 * 1024 * 1024);
+  });
+
+  it('exports the expected ALLOWED_MIME_TYPES', () => {
+    expect(ALLOWED_MIME_TYPES).toEqual(
+      expect.arrayContaining([
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'application/pdf',
+      ]),
+    );
   });
 });

--- a/meridian-api/src/upload/upload.service.ts
+++ b/meridian-api/src/upload/upload.service.ts
@@ -1,4 +1,84 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { StorageProvider } from './storage-provider.interface';
+
+/**
+ * Magic-byte signatures for allowed file types.
+ *
+ * Each entry maps a MIME type to one or more byte sequences that should appear
+ * at the start of a valid file of that type.  Checking magic bytes prevents
+ * attackers from bypassing the MIME-type filter by renaming a file.
+ */
+const MAGIC_BYTES: Record<string, Buffer[]> = {
+  'image/jpeg': [Buffer.from([0xff, 0xd8, 0xff])],
+  'image/png': [Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
+  'image/gif': [
+    Buffer.from([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]), // GIF87a
+    Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]), // GIF89a
+  ],
+  'application/pdf': [Buffer.from([0x25, 0x50, 0x44, 0x46])], // %PDF
+};
+
+/** MIME types accepted by this service (mirrors the controller's FileTypeValidator). */
+export const ALLOWED_MIME_TYPES = Object.keys(MAGIC_BYTES);
+
+/** Maximum file size in bytes (5 MB). Also enforced at the controller layer. */
+export const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 @Injectable()
-export class UploadService {}
+export class UploadService {
+  constructor(
+    @Inject('STORAGE_PROVIDER')
+    private readonly storageProvider: StorageProvider,
+  ) {}
+
+  async uploadFile(
+    file: Express.Multer.File,
+  ): Promise<{ url: string; originalName: string }> {
+    if (!file) {
+      throw new BadRequestException('No file uploaded or file is invalid');
+    }
+
+    this.validateMimeType(file);
+    this.validateMagicBytes(file);
+
+    const url = await this.storageProvider.uploadFile(file);
+    return { url, originalName: file.originalname };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private validateMimeType(file: Express.Multer.File): void {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new BadRequestException(
+        `File type "${file.mimetype}" is not allowed. ` +
+          `Accepted types: ${ALLOWED_MIME_TYPES.join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Validates the file buffer against known magic bytes for its declared MIME
+   * type.  This prevents simple MIME-spoofing attacks (e.g. an .exe renamed
+   * to .png with a faked Content-Type header).
+   */
+  private validateMagicBytes(file: Express.Multer.File): void {
+    const signatures = MAGIC_BYTES[file.mimetype];
+    if (!signatures) return; // guarded already by validateMimeType
+
+    const isValid = signatures.some((sig) =>
+      file.buffer.slice(0, sig.length).equals(sig),
+    );
+
+    if (!isValid) {
+      throw new BadRequestException(
+        'File content does not match its declared type (magic byte mismatch)',
+      );
+    }
+  }
+}

--- a/meridian-api/src/upload/utils/sanitize-filename.spec.ts
+++ b/meridian-api/src/upload/utils/sanitize-filename.spec.ts
@@ -1,0 +1,55 @@
+import { sanitizeFilename } from './sanitize-filename';
+
+describe('sanitizeFilename', () => {
+  it('preserves simple alphanumeric names', () => {
+    const result = sanitizeFilename('photo.png');
+    expect(result).toMatch(/^\d+-photo\.png$/);
+  });
+
+  it('strips path traversal sequences', () => {
+    const result = sanitizeFilename('../../etc/passwd');
+    expect(result).not.toContain('..');
+    expect(result).not.toContain('/');
+    expect(result).not.toContain('\\');
+  });
+
+  it('replaces special characters with underscores', () => {
+    const result = sanitizeFilename('my file #1 (final)$.png');
+    expect(result).not.toMatch(/[#$()\s]/);
+    expect(result).toMatch(/\.png$/);
+  });
+
+  it('strips double extensions – keeps only the last one', () => {
+    const result = sanitizeFilename('malware.php.png');
+    // stem "malware.php" → "malware_php", ext kept is ".png"
+    expect(result).toMatch(/\.png$/);
+    expect(result).not.toContain('.php.');
+  });
+
+  it('lowercases the extension', () => {
+    const result = sanitizeFilename('IMAGE.JPEG');
+    expect(result).toMatch(/\.jpeg$/);
+  });
+
+  it('adds a timestamp prefix for uniqueness', () => {
+    const before = Date.now();
+    const result = sanitizeFilename('test.pdf');
+    const after = Date.now();
+    const ts = parseInt(result.split('-')[0], 10);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('handles filenames with no extension', () => {
+    const result = sanitizeFilename('Makefile');
+    // No extension → result ends with just the sanitized stem
+    expect(result).toMatch(/^\d+-Makefile$/);
+  });
+
+  it('handles filenames that are only special characters', () => {
+    const result = sanitizeFilename('###.png');
+    expect(result).toMatch(/\.png$/);
+    // stem becomes underscores – still a valid string
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/meridian-api/src/upload/utils/sanitize-filename.ts
+++ b/meridian-api/src/upload/utils/sanitize-filename.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+
+/**
+ * Sanitizes an uploaded filename so it is safe to use on disk or as an S3 key.
+ *
+ * Rules applied (in order):
+ *  1. Strip any leading directory components (path traversal prevention).
+ *  2. Extract the last extension only — prevents double-extension attacks
+ *     (e.g. "malware.php.png" → extension kept is ".png").
+ *  3. Replace every character that is not alphanumeric, a hyphen, or an
+ *     underscore with "_".  Dots are preserved only in the single extension.
+ *  4. Collapse consecutive underscores to a single underscore.
+ *  5. Prefix with a millisecond timestamp to guarantee uniqueness and avoid
+ *     name collisions.
+ *
+ * @param originalName – the raw `file.originalname` from multer
+ * @returns a safe, unique filename string (no path separator, no "..")
+ */
+export function sanitizeFilename(originalName: string): string {
+  // 1. Prevent path traversal — keep only the base part.
+  const base = path.basename(originalName);
+
+  // 2. Extract the final extension only (defends against double extensions).
+  const ext = path.extname(base).toLowerCase(); // e.g. ".png"
+  const nameWithoutExt = path.basename(base, ext); // e.g. "malware.php"
+
+  // 3. Sanitize the stem: allow only alphanumerics, hyphens, underscores.
+  const safeStem = nameWithoutExt.replace(/[^a-zA-Z0-9\-]/g, '_');
+
+  // 4. Collapse consecutive underscores/hyphens for readability.
+  const cleanStem = safeStem.replace(/_+/g, '_').replace(/-+/g, '-');
+
+  // 5. Sanitize extension characters (should only be alpha, but be safe).
+  const safeExt = ext.replace(/[^a-z0-9.]/g, '');
+
+  // 6. Timestamp prefix for uniqueness.
+  return `${Date.now()}-${cleanStem}${safeExt}`;
+}


### PR DESCRIPTION
- Add strict MIME-type validation via NestJS FileTypeValidator (header level)
- Add magic-byte validation in UploadService to prevent MIME-spoofing attacks
- Sanitize filenames: strip path traversal, double extensions, and special chars
- LocalStorageProvider: safe dir creation (0o755), path-traversal guard on write
- S3StorageProvider: real @aws-sdk/client-s3 PutObjectCommand integration, supports explicit credentials or SDK default credential chain
- Add upload.config.ts using registerAs() pattern (consistent with jwt.config.ts)
- Add shared sanitizeFilename() utility (DRY across both providers)
- Add unit tests: 39 tests across 5 suites covering happy paths and edge cases (spoofed MIME, path traversal, double extension, missing config, SDK errors)

Closes #451