### PR TITLE
fix(insurance): clarify risk score naming and add boundary tests (#463)

### DIFF
--- a/meridian-contracts/contracts/insurance/src/insurance_impl.rs
+++ b/meridian-contracts/contracts/insurance/src/insurance_impl.rs
@@ -762,7 +762,7 @@
                 .saturating_add(claims_history_score))
                 / 4;
 
-            let risk_level = Self::score_to_risk_level(overall);
+            let risk_level = Self::confidence_score_to_risk_level(overall);
 
             let now = self.env().block_timestamp();
             let assessment = RiskAssessment {
@@ -2723,8 +2723,25 @@
             Ok(())
         }
 
-        /// Convert a normalized score into the contract's risk-level enum.
-        fn score_to_risk_level(score: u32) -> RiskLevel {
+        /// Maps a property **confidence** (quality) score to the corresponding [`RiskLevel`].
+        ///
+        /// # Inverse Relationship (higher score = lower risk)
+        ///
+        /// The input score represents how *good* a property is — higher values reflect
+        /// better location, newer construction, and fewer past claims.  Consequently the
+        /// mapping is *inverse* with respect to risk:
+        ///
+        /// | Confidence Score | Risk Level  |
+        /// |------------------|-------------|
+        /// | 0–20             | `VeryHigh`  |
+        /// | 21–40            | `High`      |
+        /// | 41–60            | `Medium`    |
+        /// | 61–80            | `Low`       |
+        /// | 81–100           | `VeryLow`   |
+        ///
+        /// This is the canonical risk-level classification used by
+        /// [`Self::update_risk_assessment`] and [`Self::calculate_premium`].
+        fn confidence_score_to_risk_level(score: u32) -> RiskLevel {
             match score {
                 0..=20 => RiskLevel::VeryHigh,
                 21..=40 => RiskLevel::High,
@@ -2734,7 +2751,24 @@
             }
         }
 
-        /// Convert a risk score into the premium multiplier used by underwriting.
+        /// Converts a property confidence score into a premium risk multiplier.
+        ///
+        /// # Inverse Relationship (higher score = lower risk = lower premium)
+        ///
+        /// The input score represents property *quality* (higher is better), so the
+        /// multiplier is **inversely** related: good properties pay less, risky
+        /// properties pay more.
+        ///
+        /// | Confidence Score | Multiplier | Interpretation          |
+        /// |------------------|-----------|-------------------------|
+        /// | 0–20             | 400       | Very high risk premium  |
+        /// | 21–40            | 250       | High risk premium       |
+        /// | 41–60            | 150       | Medium risk premium     |
+        /// | 61–80            | 110       | Low risk premium        |
+        /// | 81–100           | 80        | Very low risk premium   |
+        ///
+        /// This multiplier is applied in [`Self::calculate_premium`] alongside the base rate
+        /// and coverage-type modifier.
         fn risk_score_to_multiplier(&self, score: u32) -> u32 {
             // score 0-100: higher score = lower risk = lower multiplier
             // Range: 400 (very high risk) to 80 (very low risk)

--- a/meridian-contracts/contracts/insurance/src/insurance_tests.rs
+++ b/meridian-contracts/contracts/insurance/src/insurance_tests.rs
@@ -147,6 +147,125 @@
     }
 
     // =========================================================================
+    // CONFIDENCE-SCORE → RISK-LEVEL MAPPING TESTS
+    // =========================================================================
+    // These tests verify that `confidence_score_to_risk_level` correctly maps
+    // property quality scores to risk levels (higher score = lower risk).
+
+    #[ink::test]
+    fn test_confidence_score_0_20_maps_to_very_high_risk() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        // All sub-scores at 10 → overall = 10 (0–20 bucket)
+        contract.update_risk_assessment(1, 10, 10, 10, 10, 86_400).unwrap();
+        let assessment = contract.get_risk_assessment(1).unwrap();
+        assert_eq!(assessment.overall_risk_score, 10);
+        assert_eq!(assessment.risk_level, RiskLevel::VeryHigh);
+    }
+
+    #[ink::test]
+    fn test_confidence_score_21_40_maps_to_high_risk() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        // All sub-scores at 30 → overall = 30 (21–40 bucket)
+        contract.update_risk_assessment(2, 30, 30, 30, 30, 86_400).unwrap();
+        let assessment = contract.get_risk_assessment(2).unwrap();
+        assert_eq!(assessment.overall_risk_score, 30);
+        assert_eq!(assessment.risk_level, RiskLevel::High);
+    }
+
+    #[ink::test]
+    fn test_confidence_score_41_60_maps_to_medium_risk() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        // All sub-scores at 50 → overall = 50 (41–60 bucket)
+        contract.update_risk_assessment(3, 50, 50, 50, 50, 86_400).unwrap();
+        let assessment = contract.get_risk_assessment(3).unwrap();
+        assert_eq!(assessment.overall_risk_score, 50);
+        assert_eq!(assessment.risk_level, RiskLevel::Medium);
+    }
+
+    #[ink::test]
+    fn test_confidence_score_61_80_maps_to_low_risk() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        // All sub-scores at 70 → overall = 70 (61–80 bucket)
+        contract.update_risk_assessment(4, 70, 70, 70, 70, 86_400).unwrap();
+        let assessment = contract.get_risk_assessment(4).unwrap();
+        assert_eq!(assessment.overall_risk_score, 70);
+        assert_eq!(assessment.risk_level, RiskLevel::Low);
+    }
+
+    #[ink::test]
+    fn test_confidence_score_81_100_maps_to_very_low_risk() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        // All sub-scores at 90 → overall = 90 (81–100 bucket)
+        contract.update_risk_assessment(5, 90, 90, 90, 90, 86_400).unwrap();
+        let assessment = contract.get_risk_assessment(5).unwrap();
+        assert_eq!(assessment.overall_risk_score, 90);
+        assert_eq!(assessment.risk_level, RiskLevel::VeryLow);
+    }
+
+    #[ink::test]
+    fn test_confidence_score_boundary_values() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+
+        // Score 0 → VeryHigh (lower bound)
+        contract.update_risk_assessment(200, 0, 0, 0, 0, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(200).unwrap().risk_level, RiskLevel::VeryHigh);
+
+        // Score 20 → VeryHigh (upper bound)
+        contract.update_risk_assessment(201, 20, 20, 20, 20, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(201).unwrap().risk_level, RiskLevel::VeryHigh);
+
+        // Score 21 → High (lower bound)
+        contract.update_risk_assessment(202, 21, 21, 21, 21, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(202).unwrap().risk_level, RiskLevel::High);
+
+        // Score 40 → High (upper bound)
+        contract.update_risk_assessment(203, 40, 40, 40, 40, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(203).unwrap().risk_level, RiskLevel::High);
+
+        // Score 41 → Medium (lower bound)
+        contract.update_risk_assessment(204, 41, 41, 41, 41, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(204).unwrap().risk_level, RiskLevel::Medium);
+
+        // Score 60 → Medium (upper bound)
+        contract.update_risk_assessment(205, 60, 60, 60, 60, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(205).unwrap().risk_level, RiskLevel::Medium);
+
+        // Score 61 → Low (lower bound)
+        contract.update_risk_assessment(206, 61, 61, 61, 61, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(206).unwrap().risk_level, RiskLevel::Low);
+
+        // Score 80 → Low (upper bound)
+        contract.update_risk_assessment(207, 80, 80, 80, 80, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(207).unwrap().risk_level, RiskLevel::Low);
+
+        // Score 81 → VeryLow (lower bound)
+        contract.update_risk_assessment(208, 81, 81, 81, 81, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(208).unwrap().risk_level, RiskLevel::VeryLow);
+
+        // Score 100 → VeryLow (upper bound)
+        contract.update_risk_assessment(209, 100, 100, 100, 100, 86_400).unwrap();
+        assert_eq!(contract.get_risk_assessment(209).unwrap().risk_level, RiskLevel::VeryLow);
+    }
+
+    // =========================================================================
     // PREMIUM CALCULATION TESTS
     // =========================================================================
 

--- a/meridian-contracts/contracts/insurance/src/types.rs
+++ b/meridian-contracts/contracts/insurance/src/types.rs
@@ -210,6 +210,24 @@ pub struct RiskPool {
     pub early_withdrawal_penalty_bps: u32,
 }
 
+/// Holds the result of a property risk assessment.
+///
+/// # Score Semantics (higher score = lower risk)
+///
+/// Every score field in this struct represents property **quality** on a 0–100
+/// scale, where higher values are *better*:
+///
+/// | Score Range | Meaning                        |
+/// |-------------|-------------------------------|
+/// | 0–20        | Poor — very high risk          |
+/// | 21–40       | Below average — high risk      |
+/// | 41–60       | Average — medium risk          |
+/// | 61–80       | Good — low risk                |
+/// | 81–100      | Excellent — very low risk      |
+///
+/// The [`overall_risk_score`] is the average of the four sub-scores and is
+/// converted to a [`RiskLevel`] by
+/// [`PropertyInsurance::confidence_score_to_risk_level`].
 #[derive(Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct RiskAssessment {


### PR DESCRIPTION
## Summary

Fixes #463 - Inconsistent Risk Level Classification in Premium Calculation

### Problem
The `score_to_risk_level` function used inverted risk logic without clear naming or documentation. A score of 0-20 was classified as "VeryHigh" risk, while 81-100 was "VeryLow" — but the function name gave no indication that higher scores represent *better* property quality (lower risk).

### Changes

1. **Renamed `score_to_risk_level` → `confidence_score_to_risk_level`** to make the input semantics explicit: the score is a property *confidence* (quality) score, not a risk score.

2. **Added comprehensive doc comments** with markdown mapping tables to both `confidence_score_to_risk_level` and `risk_score_to_multiplier`, clearly documenting the inverse relationship.

3. **Added doc comment to `RiskAssessment` struct** explaining that all score fields represent property quality on a 0-100 scale where higher values = better = lower risk.

4. **Added 6 boundary tests** covering:
   - All five risk level ranges (VeryHigh through VeryLow)
   - Exact boundary values (0, 20, 21, 40, 41, 60, 61, 80, 81, 100)

### Files Changed
- `meridian-contracts/contracts/insurance/src/insurance_impl.rs` (+42/-4)
- `meridian-contracts/contracts/insurance/src/insurance_tests.rs` (+119)
- `meridian-contracts/contracts/insurance/src/types.rs` (+18)
