### PR TITLE
test(users): update DELETE test to call /users/:id and assert service…

### DIFF
--- a/meridian-api/src/users/users.controller.spec.ts
+++ b/meridian-api/src/users/users.controller.spec.ts
@@ -157,11 +157,13 @@ describe('UsersController (integration)', () => {
     expect(userService.createMany).toHaveBeenCalledWith(dto);
   });
 
-  it('DELETE /users responds with status 200', async () => {
+  it('DELETE /users/:id responds with status 200', async () => {
     const response = await request(app.getHttpServer())
-      .delete('/users')
+      .delete('/users/1')
       .expect(200);
+
     expect(response).toBeDefined();
+    expect(userService.deleteUser).toHaveBeenCalledWith(1);
   });
 
   it('PATCH /users updates user details', async () => {


### PR DESCRIPTION
closes #494 
Summary
Fix a failing test in the users controller spec by updating the request path to match the controller route. This is a test-only change that makes the spec call DELETE /users/1 and asserts the service invocation.

Changes
Updated test to call /users/1 instead of /users
Added assertion that userService.deleteUser(1) is called
Files
users.controller.spec.ts — updated test
users.controller.ts — unchanged (kept @Delete('/:id'))
How to run locally

Test output (targeted run)
PASS src/users/users.controller.spec.ts
Test Suites: 1 passed, 1 total
Tests: 17 passed, 17 total

Acceptance checklist
 Test updated to call DELETE /users/:id
 Test asserts userService.deleteUser called with parsed id
 Targeted spec passes locally
Commit & branch
Commit: test(users): update DELETE test to call /users/:id and assert service call
Branch: fix/users-delete-route-test
Follow-ups
If a DELETE /users (delete-all) endpoint is desired, open a new issue/PR and implement with appropriate authorization and safeguards.
Optionally add response-body assertions for the delete endpoint if the service returns structured output.