### PR TITLE
feat: extend rate limiting to all endpoints

### DIFF
--- a/meridian-api/src/app.module.ts
+++ b/meridian-api/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_INTERCEPTOR, APP_GUARD } from '@nestjs/core';
+import { CustomThrottlerGuard } from './common/guards/custom-throttler.guard';
 import { DataSource } from 'typeorm';
 
 import { AppController } from './app.controller';
@@ -50,8 +51,14 @@ import { AuditModule } from './audit/audit.module';
      */
     ThrottlerModule.forRoot([
       {
+        name: 'read',
         ttl: 60000,
-        limit: 10,
+        limit: 100, // 100 requests per minute for GET
+      },
+      {
+        name: 'write',
+        ttl: 60000,
+        limit: 20, // 20 requests per minute for POST/PUT/PATCH/DELETE
       },
     ]),
 
@@ -117,7 +124,7 @@ import { AuditModule } from './audit/audit.module';
     },
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: CustomThrottlerGuard,
     },
     AccessTokenGuard,
     MailProvider,

--- a/meridian-api/src/auth/auth.controller.ts
+++ b/meridian-api/src/auth/auth.controller.ts
@@ -25,7 +25,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('/sign-in')
-  @Throttle({ default: { limit: 5, ttl: 15000 } })
+  @Throttle({ write: { limit: 5, ttl: 15000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Sign in with user credentials' })
   @ApiResponse({
@@ -42,7 +42,7 @@ export class AuthController {
   }
 
   @Post('/refresh-token')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Throttle({ write: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Refresh Auth Token' })
   @ApiResponse({ status: 200, description: 'Successfully refreshed token' })
@@ -97,7 +97,7 @@ export class AuthController {
   }
 
   @Post('/verify-email')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Throttle({ write: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Verify email with one-time token from signup mail',
@@ -113,7 +113,7 @@ export class AuthController {
   }
 
   @Post('/resend-verification')
-  @Throttle({ default: { limit: 3, ttl: 60000 } })
+  @Throttle({ write: { limit: 3, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Resend the email verification mail' })
   @ApiResponse({

--- a/meridian-api/src/common/guards/custom-throttler.guard.ts
+++ b/meridian-api/src/common/guards/custom-throttler.guard.ts
@@ -1,0 +1,27 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class CustomThrottlerGuard extends ThrottlerGuard {
+  protected async handleRequest(
+    requestProps: any,
+  ): Promise<boolean> {
+    const { context, throttler } = requestProps;
+
+    const req = context.switchToHttp().getRequest();
+    const isWrite = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method);
+    const throttlerName = throttler.name || 'default';
+
+    // If it's a read request, ignore the "write" throttler
+    if (!isWrite && throttlerName === 'write') {
+      return true;
+    }
+
+    // If it's a write request, ignore the "read" throttler
+    if (isWrite && throttlerName === 'read') {
+      return true;
+    }
+
+    return super.handleRequest(requestProps);
+  }
+}

--- a/meridian-api/src/health/health.controller.ts
+++ b/meridian-api/src/health/health.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import {
   HealthCheckService,
   HealthCheck,
@@ -8,6 +9,7 @@ import {
 } from '@nestjs/terminus';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
+@SkipThrottle()
 @ApiTags('Health')
 @Controller('health')
 export class HealthController {


### PR DESCRIPTION
I've corrected the type signature in  custom-throttler.guard.ts  for 
  @nestjs/throttler  v6 and restarted the build. It should complete correctly
  this time. I will finish up once the task sends a final success
  notification!

▸ Thought for 1s
  Prioritizing Tool Usage
  The NestJS application has successfully compiled and I've implemented the
  requested rate limiting changes.

  Here is a summary of the changes made:
  1. Configured Read vs. Write Limits ( app.module.ts ):
      • I updated the  ThrottlerModule.forRoot()  configuration to define two
      separate limiters:
          •  read : 100 requests per 60 seconds (generous limit for fetching
          data).
          •  write : 20 requests per 60 seconds (stricter limit for data
          modification).
  2. Implemented Smart Request Throttling ( custom-throttler.guard.ts ):
      • Instead of manually wrapping every controller route in decorators, I
      created a  CustomThrottlerGuard  and globally bound it in  app.module.
      ts .
      • The guard detects the HTTP method to automatically apply the correct
      limit group:
          •  GET  requests skip the  write  throttler and only decrement the 
          read  throttler.
          •  POST ,  PUT ,  PATCH , and  DELETE  requests skip the  read 
          throttler and decrement the strict  write  throttler.

  3. Skipped Throttling on Health Checks ( health.controller.ts ):
      • I added the  @SkipThrottle()  decorator to the  HealthController  so
      that constant pings from load balancers or container orchestrators do
      not trigger a false-positive rate limit outage.
  4. Preserved Explicit Auth Rates ( auth.controller.ts ):
      • The existing endpoints in the Auth Controller were overriding the old
      default  throttler limits. I migrated those explicit rates (e.g., 5
      requests per 15 seconds for  /sign-in  and 3 per 60 seconds for 
      /resend-verification ) to correctly target the new  write  throttler
      name, ensuring your strict anti-bruteforce rules remain completely
      intact.
      
      closes #475 