### PR TITLE
Add secure auth register and reset flow

### DIFF
--- a/meridian-web/app/auth/register/page.tsx
+++ b/meridian-web/app/auth/register/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+import { AuthShell } from '@/components/auth/auth-shell'
+import { FormInput } from '@/components/form/FormInput'
+import { FormWrapper } from '@/components/form/FormWrapper'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { RegisterSchema, type RegisterDto } from '@/lib/validations/auth'
+
+const DEFAULT_VALUES: RegisterDto = {
+  email: '',
+  password: '',
+  confirmPassword: '',
+}
+
+export default function RegisterPage() {
+  const router = useRouter()
+
+  async function handleRegister(data: RegisterDto) {
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: data.email,
+        password: data.password,
+      }),
+    })
+
+    if (!res.ok) {
+      const body = (await res.json()) as { message?: string }
+      toast.error(body?.message ?? 'Registration failed. Please try again.')
+      return
+    }
+
+    toast.success('Account created successfully!')
+    router.push('/auth/sign-in')
+  }
+
+  return (
+    <AuthShell
+      title="Create an account"
+      description="Join Meridians Verse with a few details and a strong password."
+      footer={
+        <p>
+          Already have an account?{' '}
+          <Link href="/auth/sign-in" className="font-medium text-primary underline-offset-4 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      }
+    >
+      <FormWrapper
+        schema={RegisterSchema}
+        defaultValues={DEFAULT_VALUES}
+        onSubmit={handleRegister}
+        className="space-y-4"
+      >
+        {({ formState: { isSubmitting, isValid } }) => (
+          <>
+            <FormInput<RegisterDto>
+              name="email"
+              label="Email"
+              type="email"
+              placeholder="you@example.com"
+              autoComplete="email"
+              description="We’ll use this to sign you in and send updates."
+            />
+
+            <FormInput<RegisterDto>
+              name="password"
+              label="Password"
+              type="password"
+              placeholder="Create a password"
+              autoComplete="new-password"
+              description="Use at least 8 characters with an uppercase letter and a number."
+            />
+
+            <FormInput<RegisterDto>
+              name="confirmPassword"
+              label="Confirm password"
+              type="password"
+              placeholder="Repeat your password"
+              autoComplete="new-password"
+            />
+
+            <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">Password rules</p>
+              <ul className="mt-2 space-y-1">
+                <li>• At least 8 characters</li>
+                <li>• Includes an uppercase letter</li>
+                <li>• Includes a number</li>
+                <li>• Must match the confirmation field</li>
+              </ul>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={isSubmitting || !isValid}>
+              {isSubmitting ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="size-4" />
+                  Creating account…
+                </span>
+              ) : (
+                'Create account'
+              )}
+            </Button>
+          </>
+        )}
+      </FormWrapper>
+    </AuthShell>
+  )
+}

--- a/meridian-web/app/auth/reset-password/page.tsx
+++ b/meridian-web/app/auth/reset-password/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+import { AuthShell } from '@/components/auth/auth-shell'
+import { FormInput } from '@/components/form/FormInput'
+import { FormWrapper } from '@/components/form/FormWrapper'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { RegisterSchema, type RegisterDto } from '@/lib/validations/auth'
+
+const DEFAULT_VALUES: RegisterDto = {
+  email: '',
+  password: '',
+  confirmPassword: '',
+}
+
+export default function ResetPasswordPage() {
+  const router = useRouter()
+
+  async function handleResetPassword(data: RegisterDto) {
+    const res = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: data.email,
+        password: data.password,
+      }),
+    })
+
+    if (!res.ok) {
+      const body = (await res.json()) as { message?: string }
+      toast.error(body?.message ?? 'Password reset failed. Please try again.')
+      return
+    }
+
+    toast.success('Password reset successfully!')
+    router.push('/auth/sign-in')
+  }
+
+  return (
+    <AuthShell
+      title="Reset your password"
+      description="Create a fresh password and confirm it below."
+      footer={
+        <p>
+          Remembered your password?{' '}
+          <Link href="/auth/sign-in" className="font-medium text-primary underline-offset-4 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      }
+    >
+      <FormWrapper
+        schema={RegisterSchema}
+        defaultValues={DEFAULT_VALUES}
+        onSubmit={handleResetPassword}
+        className="space-y-4"
+      >
+        {({ formState: { isSubmitting, isValid } }) => (
+          <>
+            <FormInput<RegisterDto>
+              name="email"
+              label="Email"
+              type="email"
+              placeholder="you@example.com"
+              autoComplete="email"
+              description="Enter the email associated with your account."
+            />
+
+            <FormInput<RegisterDto>
+              name="password"
+              label="New password"
+              type="password"
+              placeholder="Enter a new password"
+              autoComplete="new-password"
+              description="Use at least 8 characters with an uppercase letter and a number."
+            />
+
+            <FormInput<RegisterDto>
+              name="confirmPassword"
+              label="Confirm new password"
+              type="password"
+              placeholder="Repeat your new password"
+              autoComplete="new-password"
+            />
+
+            <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">Password rules</p>
+              <ul className="mt-2 space-y-1">
+                <li>• At least 8 characters</li>
+                <li>• Includes an uppercase letter</li>
+                <li>• Includes a number</li>
+                <li>• Must match the confirmation field</li>
+              </ul>
+            </div>
+
+            <Button type="submit" className="w-full" disabled={isSubmitting || !isValid}>
+              {isSubmitting ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="size-4" />
+                  Resetting password…
+                </span>
+              ) : (
+                'Reset password'
+              )}
+            </Button>
+          </>
+        )}
+      </FormWrapper>
+    </AuthShell>
+  )
+}

--- a/meridian-web/app/auth/sign-in/page.tsx
+++ b/meridian-web/app/auth/sign-in/page.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 
-import { FormWrapper } from '@/components/form/FormWrapper'
+import { AuthShell } from '@/components/auth/auth-shell'
 import { FormInput } from '@/components/form/FormInput'
+import { FormWrapper } from '@/components/form/FormWrapper'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { SignInSchema, type SignInDto } from '@/lib/validations/auth'
@@ -32,58 +34,64 @@ export default function SignInPage() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center p-4">
-      <div className="w-full max-w-sm space-y-6">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-          <p className="text-muted-foreground text-sm">
-            Enter your email and password to continue.
+    <AuthShell
+      title="Sign in"
+      description="Enter your email and password to continue."
+      footer={
+        <div className="space-y-2 text-sm">
+          <p>
+            Don&apos;t have an account?{' '}
+            <Link href="/auth/register" className="font-medium text-primary underline-offset-4 hover:underline">
+              Create one
+            </Link>
+          </p>
+          <p>
+            Forgot your password?{' '}
+            <Link href="/auth/reset-password" className="font-medium text-primary underline-offset-4 hover:underline">
+              Reset it
+            </Link>
           </p>
         </div>
+      }
+    >
+      <FormWrapper
+        schema={SignInSchema}
+        defaultValues={DEFAULT_VALUES}
+        onSubmit={handleSignIn}
+        className="space-y-4"
+      >
+        {({ formState: { isSubmitting, isValid } }) => (
+          <>
+            <FormInput<SignInDto>
+              name="email"
+              label="Email"
+              type="email"
+              placeholder="you@example.com"
+              autoComplete="email"
+              description="The email you registered with."
+            />
 
-        <FormWrapper
-          schema={SignInSchema}
-          defaultValues={DEFAULT_VALUES}
-          onSubmit={handleSignIn}
-          className="space-y-4"
-        >
-          {({ formState: { isSubmitting, isValid } }) => (
-            <>
-              <FormInput<SignInDto>
-                name="email"
-                label="Email"
-                type="email"
-                placeholder="you@example.com"
-                autoComplete="email"
-                description="The email you registered with."
-              />
+            <FormInput<SignInDto>
+              name="password"
+              label="Password"
+              type="password"
+              placeholder="••••••••"
+              autoComplete="current-password"
+            />
 
-              <FormInput<SignInDto>
-                name="password"
-                label="Password"
-                type="password"
-                placeholder="••••••••"
-                autoComplete="current-password"
-              />
-
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={isSubmitting || !isValid}
-              >
-                {isSubmitting ? (
-                  <span className="flex items-center gap-2">
-                    <Spinner className="size-4" />
-                    Signing in…
-                  </span>
-                ) : (
-                  'Sign in'
-                )}
-              </Button>
-            </>
-          )}
-        </FormWrapper>
-      </div>
-    </main>
+            <Button type="submit" className="w-full" disabled={isSubmitting || !isValid}>
+              {isSubmitting ? (
+                <span className="flex items-center gap-2">
+                  <Spinner className="size-4" />
+                  Signing in…
+                </span>
+              ) : (
+                'Sign in'
+              )}
+            </Button>
+          </>
+        )}
+      </FormWrapper>
+    </AuthShell>
   )
 }

--- a/meridian-web/components/auth/auth-shell.tsx
+++ b/meridian-web/components/auth/auth-shell.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface AuthShellProps {
+  title: string
+  description: string
+  children: React.ReactNode
+  footer?: React.ReactNode
+  className?: string
+}
+
+export function AuthShell({
+  title,
+  description,
+  children,
+  footer,
+  className,
+}: AuthShellProps) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-4 sm:p-6">
+      <div className="w-full max-w-md">
+        <Card className={cn('border-border/60 shadow-sm', className)}>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-2xl font-semibold tracking-tight">
+              {title}
+            </CardTitle>
+            <CardDescription className="text-sm leading-6">
+              {description}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>{children}</CardContent>
+        </Card>
+        {footer ? <div className="mt-4 text-center text-sm">{footer}</div> : null}
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
Closes #539: Implement secure signup and password reset flow with validation and UI polish

This update adds a complete frontend authentication experience for user sign-up and password reset. It introduces routeable pages for /auth/register and /auth/reset-password, reuses the existing form wrapper and input components, and applies the existing Zod-based validation rules for password strength and confirmation. The new flows also include inline password guidance, responsive styling, and a polished auth layout that matches the rest of the app.

What was added
Register page under app/auth/register
Reset password page under app/auth/reset-password
Updated sign-in page with links to register and reset password
Shared auth shell for consistent, mobile-friendly UI
Password validation and confirmation feedback