### PR TITLE
Add a dynamic onboarding CTA section with A/B-ready variant support

### DIFF
--- a/meridian-web/components/sections/CTA.tsx
+++ b/meridian-web/components/sections/CTA.tsx
@@ -1,11 +1,66 @@
 'use client';
 
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 
-export function CTA() {
+import { cn } from '@/lib/utils';
+import {
+  CTA_QUERY_PARAM,
+  CTA_VARIANTS,
+  DEFAULT_CTA_VARIANT,
+  resolveCtaVariant,
+  type CtaButtonStyle,
+  type CtaVariant,
+  type CtaVariantId,
+} from '@/lib/cta-variants';
+
+interface CTAProps {
+  /**
+   * Explicitly select a variant. When omitted, the variant is resolved from
+   * the `?cta=` query param (e.g. `/?cta=member`), falling back to the
+   * marketing variant.
+   */
+  variant?: CtaVariantId;
+}
+
+const BUTTON_STYLES: Record<CtaButtonStyle, string> = {
+  solid:
+    'bg-primary text-primary-foreground hover:bg-primary/90',
+  outline:
+    'border border-primary text-primary hover:bg-primary/5',
+  ghost:
+    'text-primary hover:bg-primary/10',
+};
+
+export function CTA({ variant }: CTAProps) {
+  // An explicit prop needs no query-param lookup, so skip the Suspense
+  // boundary useSearchParams requires and render directly.
+  if (variant) {
+    return <CTAContent variant={variant} />;
+  }
+
   return (
-    <section className="py-20 px-4 max-w-4xl mx-auto">
+    <Suspense fallback={<CTAContent variant={DEFAULT_CTA_VARIANT} />}>
+      <CTAFromQuery />
+    </Suspense>
+  );
+}
+
+/** Resolves the variant from the URL, e.g. `/?cta=member`. */
+function CTAFromQuery() {
+  const searchParams = useSearchParams();
+  const resolved = resolveCtaVariant(undefined, searchParams.get(CTA_QUERY_PARAM));
+  return <CTAContent variant={resolved.id as CtaVariantId} />;
+}
+
+function CTAContent({ variant }: { variant: CtaVariantId }) {
+  const { badge, heading, description, actions, footnote }: CtaVariant = CTA_VARIANTS[variant];
+
+  return (
+    <section aria-labelledby="cta-heading" className="py-20 px-4 max-w-4xl mx-auto">
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         whileInView={{ opacity: 1, scale: 1 }}
@@ -19,14 +74,28 @@ export function CTA() {
           <div className="absolute bottom-0 left-0 w-64 h-64 bg-primary/5 rounded-full blur-3xl -ml-32 -mb-32" />
         </div>
 
+        {badge && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-primary/30 bg-primary/10 mb-6"
+          >
+            <span className="w-2 h-2 rounded-full bg-primary" aria-hidden="true" />
+            <span className="text-sm font-medium text-primary">{badge}</span>
+          </motion.div>
+        )}
+
         <motion.h2
+          id="cta-heading"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
           viewport={{ once: true }}
           className="text-4xl sm:text-5xl font-bold text-foreground mb-4"
         >
-          Ready to Transform Your Productivity?
+          {heading}
         </motion.h2>
 
         <motion.p
@@ -36,7 +105,7 @@ export function CTA() {
           viewport={{ once: true }}
           className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto"
         >
-          Join thousands of users earning real value from their focus. Start your journey today and begin earning with every productive moment.
+          {description}
         </motion.p>
 
         <motion.div
@@ -46,24 +115,38 @@ export function CTA() {
           viewport={{ once: true }}
           className="flex flex-col sm:flex-row gap-4 justify-center items-center"
         >
-          <button className="px-8 py-4 rounded-full bg-primary text-primary-foreground font-semibold hover:bg-primary/90 transition-all duration-200 flex items-center gap-2 group">
-            Start Earning Now
-            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-          </button>
-          <button className="px-8 py-4 rounded-full border border-primary text-primary font-semibold hover:bg-primary/5 transition-all duration-200">
-            Learn More
-          </button>
+          {actions.map((action) => (
+            <Link
+              key={action.label}
+              href={action.href}
+              className={cn(
+                'px-8 py-4 rounded-full font-semibold transition-all duration-200 inline-flex items-center gap-2 group',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                BUTTON_STYLES[action.style]
+              )}
+            >
+              {action.label}
+              {action.withArrow && (
+                <ArrowRight
+                  aria-hidden="true"
+                  className="w-4 h-4 group-hover:translate-x-1 transition-transform"
+                />
+              )}
+            </Link>
+          ))}
         </motion.div>
 
-        <motion.p
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          viewport={{ once: true }}
-          className="text-sm text-muted-foreground mt-8"
-        >
-          No credit card required. Free to start. Premium features available.
-        </motion.p>
+        {footnote && (
+          <motion.p
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+            viewport={{ once: true }}
+            className="text-sm text-muted-foreground mt-8"
+          >
+            {footnote}
+          </motion.p>
+        )}
       </motion.div>
     </section>
   );

--- a/meridian-web/lib/cta-variants.ts
+++ b/meridian-web/lib/cta-variants.ts
@@ -1,0 +1,99 @@
+/**
+ * CTA variant registry.
+ *
+ * Each entry fully describes the copy, links, and button emphasis for one
+ * CTA rendering. Adding a new A/B test arm is a data change only — add an
+ * entry here and it becomes selectable via the `variant` prop or the
+ * `?cta=<id>` query string, with no component changes required.
+ */
+
+export type CtaButtonStyle = 'solid' | 'outline' | 'ghost';
+
+export interface CtaAction {
+  label: string;
+  href: string;
+  style: CtaButtonStyle;
+  /** Show the animated arrow icon after the label. */
+  withArrow?: boolean;
+}
+
+export interface CtaVariant {
+  id: string;
+  /** Optional eyebrow badge rendered above the heading. */
+  badge?: string;
+  heading: string;
+  description: string;
+  actions: CtaAction[];
+  footnote?: string;
+}
+
+export const CTA_VARIANTS = {
+  /** Fallback marketing CTA — shown to anonymous / unknown visitors. */
+  marketing: {
+    id: 'marketing',
+    heading: 'Ready to Transform Your Productivity?',
+    description:
+      'Join thousands of users earning real value from their focus. Start your journey today and begin earning with every productive moment.',
+    actions: [
+      {
+        label: 'Start Earning Now',
+        href: '/auth/sign-in',
+        style: 'solid',
+        withArrow: true,
+      },
+      {
+        label: 'Learn More',
+        href: '#features',
+        style: 'outline',
+      },
+    ],
+    footnote: 'No credit card required. Free to start. Premium features available.',
+  },
+  /** Member-focused onboarding CTA — shown to signed-in / returning users. */
+  member: {
+    id: 'member',
+    badge: 'Welcome back',
+    heading: 'Pick Up Where You Left Off',
+    description:
+      'Your companion is waiting. Start a focus session to keep your streak alive, earn XP, and grow your on-chain progression.',
+    actions: [
+      {
+        label: 'Start a Focus Session',
+        href: '#focus',
+        style: 'solid',
+        withArrow: true,
+      },
+      {
+        label: 'Explore Yield Pools',
+        href: '#pool',
+        style: 'ghost',
+      },
+    ],
+    footnote: 'Every session counts toward your streak. Night owl bonus active midnight–6 AM.',
+  },
+} as const satisfies Record<string, CtaVariant>;
+
+export type CtaVariantId = keyof typeof CTA_VARIANTS;
+
+export const DEFAULT_CTA_VARIANT: CtaVariantId = 'marketing';
+
+/** Query-string key used to select a variant, e.g. `/?cta=member`. */
+export const CTA_QUERY_PARAM = 'cta';
+
+export function isCtaVariantId(value: string | null | undefined): value is CtaVariantId {
+  return typeof value === 'string' && value in CTA_VARIANTS;
+}
+
+/**
+ * Resolve which variant to render. An explicit prop wins (for direct reuse
+ * of the component elsewhere); otherwise the URL param is honoured (for
+ * A/B experiment links); otherwise fall back to the marketing variant.
+ */
+export function resolveCtaVariant(
+  prop: CtaVariantId | undefined,
+  queryValue: string | null | undefined
+): CtaVariant {
+  if (prop && isCtaVariantId(prop)) return CTA_VARIANTS[prop];
+  if (isCtaVariantId(queryValue)) return CTA_VARIANTS[queryValue];
+  return CTA_VARIANTS[DEFAULT_CTA_VARIANT];
+}


### PR DESCRIPTION
 #540feat: Add dynamic onboarding CTA section with A/B-ready variant support
Close #540 
---

Summary of the issue
The homepage CTA (components/sections/CTA.tsx) was entirely static — hard-coded copy, no variant support, and no way to adapt messaging to user state or run experiments. Additionally, its action buttons were non-functional <button> elements that didn't navigate anywhere.
---
Root cause
All CTA content was inlined directly in JSX with no abstraction between what is shown (copy/actions) and how it is rendered (layout/animation). With no props and no URL awareness, there was no seam to introduce variant messaging without duplicating the whole component.
---
Solution implemented
Introduced a small, typed variant system:

lib/cta-variants.ts — a registry of CtaVariant objects (badge, heading, description, actions, footnote) plus a resolveCtaVariant() helper. Ships with two variants:
marketing (fallback) — the original copy, now with working links to /auth/sign-in and #features
member — onboarding-focused ("Pick Up Where You Left Off") pointing members to #focus and #pool
components/sections/CTA.tsx — refactored to render from the registry. Variant selection precedence: explicit variant prop → ?cta= URL param (e.g. /?cta=member) → marketing fallback. Unknown param values fall back safely.
---
Key changes made
Variants selectable via prop (<CTA variant="member" />) or URL param (?cta=member) — future A/B arms are a pure data addition to the registry
useSearchParams isolated behind a Suspense boundary so the homepage remains statically prerendered (verified via next build — / still reports ○ Static)
Dead <button>s replaced with next/link anchors, with per-variant button styling (solid / outline / ghost)
Accessibility: aria-labelledby on the section, aria-hidden decorative icons, visible focus-visible rings on actions
All existing framer-motion animations and visual design preserved
Fully type-safe: variant IDs are derived from the registry keys, so an invalid variant prop is a compile error
---
Trade-offs / considerations
Variant resolution is client-side (component is already 'use client' with framer-motion), which keeps the page static and CDN-cacheable; the marketing variant renders as the SSR/Suspense fallback, so there is no blank state
User-state-driven selection (e.g. auto-showing member for authenticated users) is intentionally left as a follow-up: there is no session/auth context on the homepage yet — once one exists, it's a one-line change at the call site (<CTA variant={isMember ? 'member' : undefined} />)
No analytics/exposure tracking was added; the registry's id field is designed to be the experiment key when instrumentation lands
---
Testing steps
cd meridian-web && pnpm install && pnpm dev
Open http://localhost:3000/ → the marketing CTA renders ("Ready to Transform Your Productivity?") with "Start Earning Now" linking to /auth/sign-in
Open http://localhost:3000/?cta=member → the member CTA renders ("Pick Up Where You Left Off") with a "Welcome back" badge and actions linking to #focus / #pool
Open http://localhost:3000/?cta=invalid → safely falls back to the marketing variant
Keyboard-tab to the CTA buttons → visible focus rings, and both actions navigate correctly
npx tsc --noEmit → passes; pnpm build → compiles, and / is still statically prerendered
---
Please kindly review this task. If there are any corrections, improvements, adjustments, or merge conflicts that you notice regarding my implementation, I'd really appreciate your feedback. I'd also love to hear your overall review of my work on this branch.Thank you!