### PR TITLE
feat(web): max LCP + bundle efficiency for homepage hero & lazy sections

### DIFF
--- a/meridian-web/app/globals.css
+++ b/meridian-web/app/globals.css
@@ -165,4 +165,31 @@
   .hover-lift {
     @apply transition-all duration-200 hover:shadow-xl hover:-translate-y-1;
   }
+
+  /**
+   * hero-fade-up — CSS-only entrance animation used by the Hero RSC.
+   * Replaces framer-motion so the hero ships zero JS and improves LCP.
+   * Each element adds a custom [animation-delay:Xms] utility class.
+   */
+  @keyframes hero-fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .hero-fade-up {
+    animation: hero-fade-up 0.6s ease-out both;
+  }
+
+  /* Respect the user's reduced-motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .hero-fade-up {
+      animation: none;
+    }
+  }
 }

--- a/meridian-web/app/layout.tsx
+++ b/meridian-web/app/layout.tsx
@@ -7,13 +7,38 @@ import { ThemeProvider } from '@/components/theme-provider'
 // `display: 'swap'` keeps text visible with a fallback font while Geist
 // loads, so web fonts never block first paint / LCP. (next/font defaults to
 // swap; we set it explicitly to document the intent.)
-const _geist = Geist({ subsets: ["latin"], display: "swap" });
-const _geistMono = Geist_Mono({ subsets: ["latin"], display: "swap" });
+// `preload: true` (default) tells Next.js to emit a <link rel="preload"> in
+// the <head> for each font file, giving the browser an early fetch hint so
+// text renders with the correct font before the main bundle arrives.
+const _geist = Geist({ subsets: ["latin"], display: "swap", preload: true });
+const _geistMono = Geist_Mono({ subsets: ["latin"], display: "swap", preload: true });
 
 export const metadata: Metadata = {
   title: 'MERIDIAN - Where Effort Meets Value',
-  description: 'A productivity-powered on-chain economy platform combining focus, payment streams, and yield opportunities.',
+  description:
+    'A productivity-powered on-chain economy platform combining focus, payment streams, and yield opportunities.',
   generator: 'v0.app',
+  /**
+   * Explicit metadataBase lets Next.js resolve relative OG image URLs to
+   * absolute URLs at build time, which is required by social crawlers.
+   * Replace with the real production origin before deploying.
+   */
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://meridian.app',
+  ),
+  openGraph: {
+    title: 'MERIDIAN - Where Effort Meets Value',
+    description:
+      'Earn by staying focused, stream payments in real-time, and participate in yield pools with zero loss.',
+    type: 'website',
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'MERIDIAN - Where Effort Meets Value',
+    description:
+      'Earn by staying focused, stream payments in real-time, and participate in yield pools with zero loss.',
+  },
   icons: {
     icon: [
       {
@@ -54,6 +79,16 @@ export default function RootLayout({
       className="bg-background"
       suppressHydrationWarning
     >
+      <head>
+        {/*
+         * Preconnect to Google Fonts CDN so the TCP/TLS handshake is done
+         * before the font CSS is requested.  This shaves ~100–300 ms off
+         * the font load time on cold connections, which directly benefits LCP
+         * when the heading is the largest contentful element.
+         */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+      </head>
       <body className="font-sans antialiased">
         <ThemeProvider
           attribute="class"

--- a/meridian-web/app/page.tsx
+++ b/meridian-web/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 // Hero and FocusSection are pure Server Components — zero JS for LCP.
@@ -13,6 +14,7 @@ import {
   FeaturesLazy,
   CTALazy,
 } from '@/components/sections/LazySections';
+import { SectionSkeleton } from '@/components/sections/SectionSkeleton';
 
 export default function Page() {
   return (
@@ -20,19 +22,36 @@ export default function Page() {
       <Header />
       <main className="pt-16">
         {/* ── Above the fold ── server-rendered for SEO and fast LCP ──────── */}
-        <Hero />
         {/*
-         * FocusSection renders its heading on the server (SSR) and defers
-         * its interactive widgets (PetProgression, TimerSelector, etc.)
-         * to client-side lazy chunks.
+         * Hero is a pure RSC — no JS shipped, CSS-only animations.
+         * FocusSection SSR-renders its heading; interactive sub-components
+         * are deferred via Suspense + dynamic() inside FocusSection.
          */}
+        <Hero />
         <FocusSection />
 
-        {/* ── Below the fold ── client-only bundles, deferred until idle ─── */}
-        <StreamSectionLazy />
-        <PoolSectionLazy />
-        <FeaturesLazy />
-        <CTALazy />
+        {/* ── Below the fold ── React.Suspense + ssr:false dynamic imports ── */}
+        {/*
+         * Each Suspense boundary is independent: one slow chunk doesn't
+         * block the others from rendering their skeletons/content.
+         * The `loading` prop on dynamic() also covers the client-side
+         * transition; Suspense handles the server-side boundary.
+         */}
+        <Suspense fallback={<SectionSkeleton variant="chart" />}>
+          <StreamSectionLazy />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton variant="chart" />}>
+          <PoolSectionLazy />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton variant="grid" />}>
+          <FeaturesLazy />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton variant="cta" />}>
+          <CTALazy />
+        </Suspense>
       </main>
       <Footer />
     </>

--- a/meridian-web/app/page.tsx
+++ b/meridian-web/app/page.tsx
@@ -1,26 +1,38 @@
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+// Hero and FocusSection are pure Server Components — zero JS for LCP.
 import { Hero } from '@/components/sections/Hero';
 import { FocusSection } from '@/components/sections/FocusSection';
-import { Features } from '@/components/sections/Features';
-import { CTA } from '@/components/sections/CTA';
-// Below-the-fold, chart-heavy sections are client-only (ssr: false) to keep
-// their JS out of the initial payload. See LazySections for the rationale.
-import { StreamSectionLazy, PoolSectionLazy } from '@/components/sections/LazySections';
+// All below-the-fold sections are lazy-loaded on the client only.
+// Their JS (recharts, framer-motion, etc.) is excluded from the initial
+// payload and fetched only when the browser is idle / the section scrolls
+// into view.  Each lazy export uses a sized SectionSkeleton to prevent CLS.
+import {
+  StreamSectionLazy,
+  PoolSectionLazy,
+  FeaturesLazy,
+  CTALazy,
+} from '@/components/sections/LazySections';
 
 export default function Page() {
   return (
     <>
       <Header />
       <main className="pt-16">
-        {/* Above the fold — server-rendered for SEO and LCP */}
+        {/* ── Above the fold ── server-rendered for SEO and fast LCP ──────── */}
         <Hero />
+        {/*
+         * FocusSection renders its heading on the server (SSR) and defers
+         * its interactive widgets (PetProgression, TimerSelector, etc.)
+         * to client-side lazy chunks.
+         */}
         <FocusSection />
-        {/* Below the fold — lazy-loaded on the client */}
+
+        {/* ── Below the fold ── client-only bundles, deferred until idle ─── */}
         <StreamSectionLazy />
         <PoolSectionLazy />
-        <Features />
-        <CTA />
+        <FeaturesLazy />
+        <CTALazy />
       </main>
       <Footer />
     </>

--- a/meridian-web/components/sections/FocusInteractive.tsx
+++ b/meridian-web/components/sections/FocusInteractive.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+/**
+ * FocusInteractive — client boundary for the three interactive focus widgets.
+ *
+ * Grouping them in one file means a single dynamic() call in LazySections
+ * downloads one chunk instead of three, reducing waterfall requests.
+ */
+import { motion } from 'framer-motion';
+import { containerVariants } from '@/lib/animations/variants';
+import { PetProgression } from './focus/PetProgression';
+import { TimerSelector } from './focus/TimerSelector';
+import { StreakDisplay } from './focus/StreakDisplay';
+
+export function FocusInteractive() {
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      className="space-y-8"
+    >
+      <PetProgression />
+      <TimerSelector />
+      <StreakDisplay />
+    </motion.div>
+  );
+}

--- a/meridian-web/components/sections/FocusSection.tsx
+++ b/meridian-web/components/sections/FocusSection.tsx
@@ -1,45 +1,35 @@
-'use client';
-
-import { motion } from 'framer-motion';
-import { containerVariants } from '@/lib/animations/variants';
-import { PetProgression } from './focus/PetProgression';
-import { TimerSelector } from './focus/TimerSelector';
-import { StreakDisplay } from './focus/StreakDisplay';
-import { SuperchargeTiers } from './focus/SuperchargeTiers';
+/**
+ * FocusSection — React Server Component shell.
+ *
+ * The section heading and layout skeleton are rendered on the server for
+ * SEO and a fast first paint (no hydration cost).  The four interactive
+ * sub-components (PetProgression, TimerSelector, StreakDisplay,
+ * SuperchargeTiers) are heavy framer-motion clients; they are lazy-loaded
+ * via LazySections so their JS is deferred until the component scrolls
+ * into view.
+ */
+import {
+  FocusInteractiveLazy,
+  SuperchargeTiersLazy,
+} from '@/components/sections/LazySections';
 
 export function FocusSection() {
   return (
     <section id="focus" className="py-20 px-4 max-w-7xl mx-auto">
-      {/* Section heading */}
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
-        className="text-center mb-16"
-      >
+      {/* Heading — SSR, zero JS, inlined styles for fast paint */}
+      <div className="text-center mb-16">
         <h2 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Focus Pillar</h2>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
           Nurture your productivity companion while earning rewards for staying focused.
         </p>
-      </motion.div>
+      </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        {/* Left — pet, timer, streaks */}
-        <motion.div
-          variants={containerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true }}
-          className="space-y-8"
-        >
-          <PetProgression />
-          <TimerSelector />
-          <StreakDisplay />
-        </motion.div>
+        {/* Left col — pet, timer, streaks — deferred until hydration */}
+        <FocusInteractiveLazy />
 
-        {/* Right — supercharge tiers */}
-        <SuperchargeTiers />
+        {/* Right col — supercharge tiers — deferred */}
+        <SuperchargeTiersLazy />
       </div>
     </section>
   );

--- a/meridian-web/components/sections/FocusSection.tsx
+++ b/meridian-web/components/sections/FocusSection.tsx
@@ -4,19 +4,21 @@
  * The section heading and layout skeleton are rendered on the server for
  * SEO and a fast first paint (no hydration cost).  The four interactive
  * sub-components (PetProgression, TimerSelector, StreakDisplay,
- * SuperchargeTiers) are heavy framer-motion clients; they are lazy-loaded
- * via LazySections so their JS is deferred until the component scrolls
- * into view.
+ * SuperchargeTiers) are heavy framer-motion clients; they are deferred
+ * via React.Suspense + dynamic() in LazySections so their JS is excluded
+ * from the initial bundle and loaded only when the browser is ready.
  */
+import { Suspense } from 'react';
 import {
   FocusInteractiveLazy,
   SuperchargeTiersLazy,
 } from '@/components/sections/LazySections';
+import { SectionSkeleton } from '@/components/sections/SectionSkeleton';
 
 export function FocusSection() {
   return (
     <section id="focus" className="py-20 px-4 max-w-7xl mx-auto">
-      {/* Heading — SSR, zero JS, inlined styles for fast paint */}
+      {/* Heading — SSR, zero JS, fast first paint */}
       <div className="text-center mb-16">
         <h2 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Focus Pillar</h2>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
@@ -25,11 +27,15 @@ export function FocusSection() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        {/* Left col — pet, timer, streaks — deferred until hydration */}
-        <FocusInteractiveLazy />
+        {/* Left col — pet, timer, streaks — deferred via Suspense */}
+        <Suspense fallback={<SectionSkeleton variant="default" />}>
+          <FocusInteractiveLazy />
+        </Suspense>
 
-        {/* Right col — supercharge tiers — deferred */}
-        <SuperchargeTiersLazy />
+        {/* Right col — supercharge tiers — deferred via Suspense */}
+        <Suspense fallback={<SectionSkeleton variant="default" />}>
+          <SuperchargeTiersLazy />
+        </Suspense>
       </div>
     </section>
   );

--- a/meridian-web/components/sections/Hero.tsx
+++ b/meridian-web/components/sections/Hero.tsx
@@ -1,71 +1,79 @@
-'use client';
-
-import { motion } from 'framer-motion';
+/**
+ * Hero — Pure React Server Component.
+ *
+ * No 'use client', no framer-motion.  All animations are CSS-only
+ * (defined in globals.css as @keyframes hero-fade-up) so zero JS is
+ * shipped for the LCP element.  This is the single biggest win for
+ * Time-to-Interactive and Largest Contentful Paint.
+ */
 import { ArrowRight } from 'lucide-react';
 
 export function Hero() {
   return (
     <section className="min-h-screen flex items-center justify-center pt-20 px-4 relative overflow-hidden">
-      {/* Animated background gradient */}
-      <div className="absolute inset-0 -z-10">
+      {/* Static background gradient — no JS needed */}
+      <div className="absolute inset-0 -z-10" aria-hidden="true">
         <div className="absolute top-1/3 left-1/4 w-96 h-96 bg-primary/20 rounded-full blur-3xl opacity-20 animate-pulse" />
         <div className="absolute bottom-1/3 right-1/4 w-96 h-96 bg-primary/10 rounded-full blur-3xl opacity-15 animate-pulse" />
       </div>
 
       <div className="max-w-4xl mx-auto text-center z-10">
         {/* Badge */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-primary/30 bg-primary/10 mb-6"
+        <div
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-primary/30 bg-primary/10 mb-6
+                     hero-fade-up [animation-delay:0ms]"
         >
-          <span className="w-2 h-2 rounded-full bg-primary" />
+          <span className="w-2 h-2 rounded-full bg-primary" aria-hidden="true" />
           <span className="text-sm font-medium text-primary">The Future of Productivity</span>
-        </motion.div>
+        </div>
 
-        {/* Main heading */}
-        <motion.h1
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.1 }}
-          className="text-5xl sm:text-6xl lg:text-7xl font-bold text-foreground mb-6 leading-tight text-balance"
+        {/* Main heading — LCP target */}
+        <h1
+          className="text-5xl sm:text-6xl lg:text-7xl font-bold text-foreground mb-6 leading-tight text-balance
+                     hero-fade-up [animation-delay:100ms]"
         >
-          Where Real-World Effort Meets <span className="text-primary">On-Chain Value</span>
-        </motion.h1>
+          Where Real-World Effort Meets{' '}
+          <span className="text-primary">On-Chain Value</span>
+        </h1>
 
         {/* Subheading */}
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="text-lg sm:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto"
+        <p
+          className="text-lg sm:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto
+                     hero-fade-up [animation-delay:200ms]"
         >
-          Earn by staying focused, stream payments in real-time, and participate in yield pools with zero loss.
-        </motion.p>
+          Earn by staying focused, stream payments in real-time, and participate in yield pools
+          with zero loss.
+        </p>
 
         {/* CTA Buttons */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          className="flex flex-col sm:flex-row gap-4 justify-center items-center"
+        <div
+          className="flex flex-col sm:flex-row gap-4 justify-center items-center
+                     hero-fade-up [animation-delay:300ms]"
         >
-          <button className="px-8 py-3 rounded-full bg-primary text-primary-foreground font-semibold hover:bg-primary/90 transition-all duration-200 flex items-center gap-2 group">
+          <a
+            href="#focus"
+            className="px-8 py-3 rounded-full bg-primary text-primary-foreground font-semibold
+                       hover:bg-primary/90 transition-all duration-200 flex items-center gap-2 group"
+          >
             Start Focus Session
-            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-          </button>
-          <button className="px-8 py-3 rounded-full border border-primary text-primary font-semibold hover:bg-primary/5 transition-all duration-200">
+            <ArrowRight
+              className="w-4 h-4 group-hover:translate-x-1 transition-transform"
+              aria-hidden="true"
+            />
+          </a>
+          <a
+            href="#features"
+            className="px-8 py-3 rounded-full border border-primary text-primary font-semibold
+                       hover:bg-primary/5 transition-all duration-200"
+          >
             Explore Features
-          </button>
-        </motion.div>
+          </a>
+        </div>
 
-        {/* Feature highlights */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-          className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-16 pt-12 border-t border-border"
+        {/* Stats row */}
+        <div
+          className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-16 pt-12 border-t border-border
+                     hero-fade-up [animation-delay:400ms]"
         >
           <div className="text-center">
             <div className="text-2xl font-bold text-primary mb-2">10K+</div>
@@ -79,7 +87,7 @@ export function Hero() {
             <div className="text-2xl font-bold text-primary mb-2">$500K</div>
             <div className="text-sm text-muted-foreground">Yield Distributed</div>
           </div>
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/meridian-web/components/sections/LazySections.tsx
+++ b/meridian-web/components/sections/LazySections.tsx
@@ -4,21 +4,60 @@ import dynamic from 'next/dynamic';
 import { SectionSkeleton } from './SectionSkeleton';
 
 /**
- * Below-the-fold sections are loaded on the client only. They depend on
- * charting libraries (recharts) and Framer Motion, so deferring them with
- * `ssr: false` keeps that JS out of the initial, server-rendered payload
- * while a skeleton holds layout space until they hydrate.
+ * LazySections — all below-the-fold or client-heavy components are loaded
+ * with `next/dynamic` so their JS is excluded from the initial HTML payload.
  *
- * Above-the-fold sections (Hero, FocusSection) are intentionally NOT here —
- * they stay server-rendered in `app/page.tsx` for SEO and a fast LCP.
+ * Render strategy:
+ *  • `ssr: false`  — skips server rendering entirely; avoids hydration cost
+ *                    for components that rely on browser APIs or heavy libs.
+ *  • `loading`     — returns a typed SectionSkeleton that matches the real
+ *                    section's rough height, preventing CLS while JS loads.
+ *
+ * Why this file exists:
+ *  Above-the-fold sections (Hero, FocusSection heading) are server-rendered
+ *  in `app/page.tsx` for SEO and a fast LCP.  Everything else lives here.
  */
+
+// ─── Focus pillar interactive sub-components ────────────────────────────────
+// Grouped into a single chunk (FocusInteractive) to avoid three parallel
+// requests for PetProgression / TimerSelector / StreakDisplay.
+
+export const FocusInteractiveLazy = dynamic(
+  () => import('./FocusInteractive').then((m) => m.FocusInteractive),
+  { ssr: false, loading: () => <SectionSkeleton variant="default" /> },
+);
+
+export const SuperchargeTiersLazy = dynamic(
+  () => import('./focus/SuperchargeTiers').then((m) => m.SuperchargeTiers),
+  { ssr: false, loading: () => <SectionSkeleton variant="default" /> },
+);
+
+// ─── Stream pillar ──────────────────────────────────────────────────────────
+// StreamChartCard depends on recharts — the largest dependency on this page.
 
 export const StreamSectionLazy = dynamic(
   () => import('./StreamSection').then((m) => m.StreamSection),
-  { ssr: false, loading: () => <SectionSkeleton /> },
+  { ssr: false, loading: () => <SectionSkeleton variant="chart" /> },
 );
+
+// ─── Pool pillar ─────────────────────────────────────────────────────────────
 
 export const PoolSectionLazy = dynamic(
   () => import('./PoolSection').then((m) => m.PoolSection),
-  { ssr: false, loading: () => <SectionSkeleton /> },
+  { ssr: false, loading: () => <SectionSkeleton variant="chart" /> },
+);
+
+// ─── Features grid ──────────────────────────────────────────────────────────
+// Uses framer-motion whileInView stagger — defer it so initial JS is smaller.
+
+export const FeaturesLazy = dynamic(
+  () => import('./Features').then((m) => m.Features),
+  { ssr: false, loading: () => <SectionSkeleton variant="grid" /> },
+);
+
+// ─── CTA ────────────────────────────────────────────────────────────────────
+
+export const CTALazy = dynamic(
+  () => import('./CTA').then((m) => m.CTA),
+  { ssr: false, loading: () => <SectionSkeleton variant="cta" /> },
 );

--- a/meridian-web/components/sections/SectionSkeleton.tsx
+++ b/meridian-web/components/sections/SectionSkeleton.tsx
@@ -1,10 +1,72 @@
-import { Skeleton } from "@/components/ui/skeleton";
+/**
+ * SectionSkeleton — placeholder shown while a lazy section hydrates.
+ *
+ * Sized and structured to roughly match the real sections so the layout
+ * does not shift when content loads (reduces CLS).
+ */
+import { Skeleton } from '@/components/ui/skeleton';
 
-export function SectionSkeleton() {
+interface SectionSkeletonProps {
+  /** Approximate visual variant so the skeleton matches the real content */
+  variant?: 'default' | 'chart' | 'grid' | 'cta';
+}
+
+export function SectionSkeleton({ variant = 'default' }: SectionSkeletonProps) {
   return (
-    <div className="w-full space-y-4 rounded-xl border border-dashed border-border p-6">
-      <Skeleton className="h-6 w-1/4" />
-      <Skeleton className="h-32 w-full" />
+    <div
+      className="w-full py-20 px-4 max-w-7xl mx-auto"
+      aria-hidden="true"
+      aria-label="Loading section…"
+    >
+      {/* Section heading placeholder */}
+      <div className="text-center mb-16 space-y-3">
+        <Skeleton className="h-10 w-64 mx-auto rounded-lg" />
+        <Skeleton className="h-5 w-96 mx-auto rounded" />
+      </div>
+
+      {variant === 'chart' && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+          {/* Chart card placeholder */}
+          <Skeleton className="h-80 w-full rounded-2xl" />
+          {/* Feature list placeholder */}
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-48 rounded" />
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-xl" />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {variant === 'grid' && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <Skeleton key={i} className="h-36 w-full rounded-xl" />
+          ))}
+        </div>
+      )}
+
+      {variant === 'cta' && (
+        <div className="max-w-4xl mx-auto">
+          <Skeleton className="h-72 w-full rounded-3xl" />
+        </div>
+      )}
+
+      {variant === 'default' && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+          <div className="space-y-6">
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-28 w-full rounded-2xl" />
+            ))}
+          </div>
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-48 rounded" />
+            {[...Array(3)].map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-xl" />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Addresses all action items from issue #526 — reducing hydration cost, improving LCP, and splitting client bundles so the initial payload only contains what's needed above the fold.

---

## Changes

### Hero → Pure React Server Component
- Removed `'use client'` and `framer-motion` from `Hero.tsx`
- Replaced JS animations with CSS-only `hero-fade-up` keyframes (defined in `globals.css`)
- Added `prefers-reduced-motion` guard
- CTA buttons converted to `<a>` anchors — no JS required for navigation
- **Net effect:** the LCP element ships zero JavaScript

### FocusSection → Server shell + lazy client sub-components
- `FocusSection.tsx` is now a pure RSC that SSR-renders the heading/text
- Created `FocusInteractive.tsx` to bundle `PetProgression`, `TimerSelector`, and `StreakDisplay` into a single lazy chunk (avoids 3 parallel network requests)
- `SuperchargeTiers` deferred via its own lazy export

### LazySections — extended coverage
Added exports for all below-the-fold client components:
- `FocusInteractiveLazy` / `SuperchargeTiersLazy`
- `StreamSectionLazy` / `PoolSectionLazy` (existing, preserved)
- `FeaturesLazy` — defers framer-motion stagger grid
- `CTALazy` — defers framer-motion CTA block

### SectionSkeleton — variant-aware, CLS-safe
- Added `variant` prop: `default | chart | grid | cta`
- Each variant mirrors the approximate height/structure of its real section
- Prevents Cumulative Layout Shift while lazy chunks load

### app/page.tsx
- Imports only `Hero` + `FocusSection` (RSC, no client JS)
- All below-the-fold sections use the new lazy exports

### app/layout.tsx — LCP resource hints
- `preload: true` on Geist/Geist Mono fonts (emits `<link rel="preload">` in `<head>`)
- `<link rel="preconnect">` hints for `fonts.googleapis.com` + `fonts.gstatic.com`
- Added `metadataBase`, `openGraph`, and `twitter` card metadata

---

## Testing
- `pnpm exec tsc --noEmit` → 0 errors
- `next build` → compiled successfully, 0 errors, all 4 pages static

---

Closes #526