### PR TITLE
feat(web): centralize section entrance animations (#537)

### DIFF
--- a/meridian-web/app/page.tsx
+++ b/meridian-web/app/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { MotionProvider } from '@/components/animations/MotionProvider';
 // Hero and FocusSection are pure Server Components — zero JS for LCP.
 import { Hero } from '@/components/sections/Hero';
 import { FocusSection } from '@/components/sections/FocusSection';
@@ -18,7 +19,7 @@ import { SectionSkeleton } from '@/components/sections/SectionSkeleton';
 
 export default function Page() {
   return (
-    <>
+    <MotionProvider>
       <Header />
       <main className="pt-16">
         {/* ── Above the fold ── server-rendered for SEO and fast LCP ──────── */}
@@ -54,6 +55,6 @@ export default function Page() {
         </Suspense>
       </main>
       <Footer />
-    </>
+    </MotionProvider>
   );
 }

--- a/meridian-web/components/animations/MotionProvider.tsx
+++ b/meridian-web/components/animations/MotionProvider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { MotionConfig } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+/**
+ * Applies the user's operating-system reduced-motion preference to every
+ * Framer Motion component on the homepage. Framer Motion removes transform
+ * animation in this mode, preventing distracting movement and layout jank.
+ */
+export function MotionProvider({ children }: { children: ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/meridian-web/components/sections/CTA.tsx
+++ b/meridian-web/components/sections/CTA.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
+import { cardReveal, sectionReveal, sectionViewport } from '@/lib/animations/variants';
 
 import { cn } from '@/lib/utils';
 import {
@@ -62,10 +63,10 @@ function CTAContent({ variant }: { variant: CtaVariantId }) {
   return (
     <section aria-labelledby="cta-heading" className="py-20 px-4 max-w-4xl mx-auto">
       <motion.div
-        initial={{ opacity: 0, scale: 0.95 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
+        variants={cardReveal}
+        initial="hidden"
+        whileInView="visible"
+        viewport={sectionViewport}
         className="bg-gradient-to-br from-primary/20 to-primary/5 border border-primary/30 rounded-3xl p-12 text-center relative overflow-hidden"
       >
         {/* Background decoration */}
@@ -76,10 +77,7 @@ function CTAContent({ variant }: { variant: CtaVariantId }) {
 
         {badge && (
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
+            variants={sectionReveal}
             className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-primary/30 bg-primary/10 mb-6"
           >
             <span className="w-2 h-2 rounded-full bg-primary" aria-hidden="true" />
@@ -89,30 +87,21 @@ function CTAContent({ variant }: { variant: CtaVariantId }) {
 
         <motion.h2
           id="cta-heading"
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          viewport={{ once: true }}
+          variants={sectionReveal}
           className="text-4xl sm:text-5xl font-bold text-foreground mb-4"
         >
           {heading}
         </motion.h2>
 
         <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.1 }}
-          viewport={{ once: true }}
+          variants={sectionReveal}
           className="text-lg text-muted-foreground mb-8 max-w-2xl mx-auto"
         >
           {description}
         </motion.p>
 
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          viewport={{ once: true }}
+          variants={sectionReveal}
           className="flex flex-col sm:flex-row gap-4 justify-center items-center"
         >
           {actions.map((action) => (
@@ -138,10 +127,7 @@ function CTAContent({ variant }: { variant: CtaVariantId }) {
 
         {footnote && (
           <motion.p
-            initial={{ opacity: 0 }}
-            whileInView={{ opacity: 1 }}
-            transition={{ duration: 0.6, delay: 0.3 }}
-            viewport={{ once: true }}
+            variants={sectionReveal}
             className="text-sm text-muted-foreground mt-8"
           >
             {footnote}

--- a/meridian-web/components/sections/Features.tsx
+++ b/meridian-web/components/sections/Features.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Brain, Shield, Zap, TrendingUp, Lock, Users } from 'lucide-react';
+import { containerVariants, itemVariants, sectionReveal, sectionViewport } from '@/lib/animations/variants';
 
 export function Features() {
   const features = [
@@ -37,35 +38,15 @@ export function Features() {
     },
   ];
 
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1,
-        delayChildren: 0.2,
-      },
-    },
-  };
-
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.5 },
-    },
-  };
-
   return (
     <section id="features" className="py-20 px-4 max-w-7xl mx-auto">
       <motion.div
         role="presentation"
         aria-hidden="true"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
+        variants={sectionReveal}
+        initial="hidden"
+        whileInView="visible"
+        viewport={sectionViewport}
         className="text-center mb-16"
       >
         <h2 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Powerful Features</h2>
@@ -80,7 +61,7 @@ export function Features() {
         variants={containerVariants}
         initial="hidden"
         whileInView="visible"
-        viewport={{ once: true }}
+        viewport={sectionViewport}
         className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
       >
         {features.map((feature) => {

--- a/meridian-web/components/sections/Hero.tsx
+++ b/meridian-web/components/sections/Hero.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { ArrowRight, DollarSign, Sparkles, Users } from 'lucide-react';
 import { CardMetric, CardMetrics } from '@/components/ui/metric-card';
+import { sectionReveal } from '@/lib/animations/variants';
 
 export function Hero() {
   return (
@@ -70,9 +71,9 @@ export function Hero() {
         <motion.div
           role="presentation"
           aria-hidden="true"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
+          variants={sectionReveal}
+          initial="hidden"
+          animate="visible"
           className="mt-16 pt-12 border-t border-border"
         >
           <CardMetrics>

--- a/meridian-web/components/sections/PoolSection.tsx
+++ b/meridian-web/components/sections/PoolSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { containerVariants } from '@/lib/animations/variants';
+import { containerVariants, sectionReveal, sectionViewport } from '@/lib/animations/variants';
 import { LeaderboardCard } from './pool/LeaderboardCard';
 import { PoolFeatureGrid } from './pool/PoolFeatureGrid';
 import { PoolStats } from './pool/PoolStats';
@@ -13,10 +13,10 @@ export function PoolSection() {
       <motion.div
         role="presentation"
         aria-hidden="true"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
+        variants={sectionReveal}
+        initial="hidden"
+        whileInView="visible"
+        viewport={sectionViewport}
         className="text-center mb-16"
       >
         <h2 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Pool Pillar</h2>
@@ -37,7 +37,7 @@ export function PoolSection() {
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
-          viewport={{ once: true }}
+          viewport={sectionViewport}
           className="space-y-6"
         >
           <h3 className="text-2xl font-bold text-foreground">No-Loss Yield</h3>

--- a/meridian-web/components/sections/StreamSection.tsx
+++ b/meridian-web/components/sections/StreamSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { containerVariants } from '@/lib/animations/variants';
+import { containerVariants, sectionReveal, sectionViewport } from '@/lib/animations/variants';
 import { StreamChartCard } from './stream/StreamChartCard';
 import { FeatureGrid } from './stream/FeatureGrid';
 import { EarningsCalculator } from './stream/EarningsCalculator';
@@ -13,10 +13,10 @@ export function StreamSection() {
       <motion.div
         role="presentation"
         aria-hidden="true"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
+        variants={sectionReveal}
+        initial="hidden"
+        whileInView="visible"
+        viewport={sectionViewport}
         className="text-center mb-16"
       >
         <h2 className="text-4xl sm:text-5xl font-bold text-foreground mb-4">Stream Pillar</h2>
@@ -37,7 +37,7 @@ export function StreamSection() {
           variants={containerVariants}
           initial="hidden"
           whileInView="visible"
-          viewport={{ once: true }}
+          viewport={sectionViewport}
           className="space-y-6"
         >
           <h3 className="text-2xl font-bold text-foreground">Continuous Compensation</h3>

--- a/meridian-web/components/sections/pool/LeaderboardCard.tsx
+++ b/meridian-web/components/sections/pool/LeaderboardCard.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Award } from 'lucide-react';
-import { containerVariants, itemVariantsLeft } from '@/lib/animations/variants';
+import { cardReveal, containerVariants, itemVariantsLeft, sectionViewport } from '@/lib/animations/variants';
 
 interface LeaderboardEntry {
   rank: number;
@@ -24,10 +24,10 @@ export function LeaderboardCard() {
     <motion.div
       role="presentation"
       aria-hidden="true"
-      initial={{ opacity: 0, scale: 0.95 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.6 }}
-      viewport={{ once: true }}
+      variants={cardReveal}
+      initial="hidden"
+      whileInView="visible"
+      viewport={sectionViewport}
       className="bg-card border border-border rounded-2xl p-8"
     >
       <div className="sr-only">Weekly Leaderboard</div>
@@ -40,7 +40,7 @@ export function LeaderboardCard() {
         variants={containerVariants}
         initial="hidden"
         whileInView="visible"
-        viewport={{ once: true }}
+        viewport={sectionViewport}
         className="space-y-3"
       >
         {leaderboard.map((entry) => (

--- a/meridian-web/components/sections/stream/StreamChartCard.tsx
+++ b/meridian-web/components/sections/stream/StreamChartCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { TrendingUp } from 'lucide-react';
+import { cardReveal, sectionViewport } from '@/lib/animations/variants';
 import {
   LineChart,
   Line,
@@ -26,10 +27,10 @@ export function StreamChartCard() {
     <motion.div
       role="presentation"
       aria-hidden="true"
-      initial={{ opacity: 0, scale: 0.95 }}
-      whileInView={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.6 }}
-      viewport={{ once: true }}
+      variants={cardReveal}
+      initial="hidden"
+      whileInView="visible"
+      viewport={sectionViewport}
       className="bg-card border border-border rounded-2xl p-8"
     >
       <h3 className="font-semibold text-foreground mb-6 flex items-center gap-2">

--- a/meridian-web/lib/animations/variants.ts
+++ b/meridian-web/lib/animations/variants.ts
@@ -5,13 +5,30 @@ import type { Variants } from 'framer-motion';
  * These are plain objects — no hooks, no context, safe to import in any file.
  */
 
+export const sectionViewport = { once: true, amount: 0.2 } as const;
+
+const revealTransition = { duration: 0.45, ease: 'easeOut' } as const;
+
+/** The standard reveal for headings and standalone content. */
+export const sectionReveal: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: revealTransition },
+};
+
+/** The standard reveal for data-heavy cards and charts. */
+export const cardReveal: Variants = {
+  hidden: { opacity: 0, scale: 0.98 },
+  visible: { opacity: 1, scale: 1, transition: revealTransition },
+};
+
+/** Coordinates section children so cards enter with a consistent cadence. */
 export const containerVariants: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
-      delayChildren: 0.2,
+      staggerChildren: 0.08,
+      delayChildren: 0.1,
     },
   },
 };
@@ -22,7 +39,7 @@ export const itemVariants: Variants = {
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.5 },
+    transition: revealTransition,
   },
 };
 
@@ -32,14 +49,15 @@ export const itemVariantsLeft: Variants = {
   visible: {
     opacity: 1,
     x: 0,
-    transition: { duration: 0.5 },
+    transition: revealTransition,
   },
 };
 
 /** Standard heading reveal used across all three sections */
-export const headingVariants = {
-  initial: { opacity: 0, y: 20 },
-  whileInView: { opacity: 1, y: 0 },
-  transition: { duration: 0.6 },
-  viewport: { once: true },
-} as const;
+export const headingVariants = sectionReveal;
+
+/** Hero content uses the same cadence but starts immediately on page load. */
+export const heroContainerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.1 } },
+};


### PR DESCRIPTION
Closes #537

Adds a shared animation orchestration layer for homepage section entrance effects.

- Centralizes reveal variants, transition timing, stagger behavior, and viewport settings in `lib/animations/variants.ts`
- Adds a global `MotionProvider` with `reducedMotion="user"` to respect `prefers-reduced-motion`
- Applies consistent entrance effects to the hero, feature cards, chart sections, leaderboard, and CTA

## Accessibility

Visitors who prefer reduced motion will not receive transform-based animations, reducing distracting movement and avoiding layout jank.

## Issue

Closes #537