### PR TITLE
feat(property-token): add bounded error logging and caller rate limiting

### DIFF
--- a/meridian-contracts/contracts/property-token/src/lib.rs
+++ b/meridian-contracts/contracts/property-token/src/lib.rs
@@ -14,6 +14,10 @@ use scale_info::prelude::vec::Vec;
 mod property_token {
     use super::*;
 
+    const MAX_ERROR_LOG: u64 = 50;
+    const ERROR_WINDOW_DURATION_MS: u64 = 3_600_000;
+    const DEFAULT_ERROR_LIMIT: u64 = 10;
+
     /// Error types for the property token contract
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
@@ -46,6 +50,7 @@ mod property_token {
         ProposalClosed,
         AskNotFound,
         InconsistentState,
+        RateLimited,
     }
 
     /// Property Token contract that maintains compatibility with ERC-721 and ERC-1155
@@ -89,9 +94,12 @@ mod property_token {
 
         // Error logging and monitoring
         error_counts: Mapping<(AccountId, String), u64>,
-        error_rates: Mapping<String, (u64, u64)>, // (count, window_start)
+        error_rates: Mapping<AccountId, ErrorRateState>,
         recent_errors: Mapping<u64, ErrorLogEntry>,
         error_log_counter: u64,
+        account_error_totals: Mapping<AccountId, u64>,
+        error_limit: u64,
+        last_error_hash: Hash,
 
         total_shares: Mapping<TokenId, u128>,
         dividends_per_share: Mapping<TokenId, u128>,
@@ -172,6 +180,9 @@ mod property_token {
                 error_rates: Mapping::default(),
                 recent_errors: Mapping::default(),
                 error_log_counter: 0,
+                account_error_totals: Mapping::default(),
+                error_limit: DEFAULT_ERROR_LIMIT,
+                last_error_hash: Hash::from([0u8; 32]),
 
                 total_shares: Mapping::default(),
                 dividends_per_share: Mapping::default(),
@@ -230,21 +241,22 @@ mod property_token {
             self.ensure_non_zero_account(&to)?;
 
             // Check if caller is authorized to transfer
-            let token_owner = self.token_owner.get(token_id).ok_or_else(|| {
-                let caller = self.env().caller();
-                self.log_error(
-                    caller,
-                    "TOKEN_NOT_FOUND".to_string(),
-                    format!("Token ID {} does not exist", token_id),
-                    vec![
-                        ("token_id".to_string(), token_id.to_string()),
-                        ("operation".to_string(), "transfer_from".to_string()),
-                    ],
-                );
-                Error::TokenNotFound
-            })?;
+            let token_owner = match self.token_owner.get(token_id) {
+                Some(owner) => owner,
+                None => {
+                    self.log_error(
+                        caller,
+                        "TOKEN_NOT_FOUND".to_string(),
+                        format!("Token ID {} does not exist", token_id),
+                        vec![
+                            ("token_id".to_string(), token_id.to_string()),
+                            ("operation".to_string(), "transfer_from".to_string()),
+                        ],
+                    )?;
+                    return Err(Error::TokenNotFound);
+                }
+            };
             if token_owner != from {
-                let caller = self.env().caller();
                 self.log_error(
                     caller,
                     "UNAUTHORIZED".to_string(),
@@ -254,7 +266,7 @@ mod property_token {
                         ("caller".to_string(), format!("{:?}", caller)),
                         ("owner".to_string(), format!("{:?}", token_owner)),
                     ],
-                );
+                )?;
                 return Err(Error::Unauthorized);
             }
 
@@ -293,18 +305,21 @@ mod property_token {
         #[ink(message)]
         pub fn approve(&mut self, to: AccountId, token_id: TokenId) -> Result<(), Error> {
             let caller = self.env().caller();
-            let token_owner = self.token_owner.get(token_id).ok_or_else(|| {
-                self.log_error(
-                    caller,
-                    "TOKEN_NOT_FOUND".to_string(),
-                    format!("Token ID {} does not exist", token_id),
-                    vec![
-                        ("token_id".to_string(), token_id.to_string()),
-                        ("operation".to_string(), "approve".to_string()),
-                    ],
-                );
-                Error::TokenNotFound
-            })?;
+            let token_owner = match self.token_owner.get(token_id) {
+                Some(owner) => owner,
+                None => {
+                    self.log_error(
+                        caller,
+                        "TOKEN_NOT_FOUND".to_string(),
+                        format!("Token ID {} does not exist", token_id),
+                        vec![
+                            ("token_id".to_string(), token_id.to_string()),
+                            ("operation".to_string(), "approve".to_string()),
+                        ],
+                    )?;
+                    return Err(Error::TokenNotFound);
+                }
+            };
 
             if token_owner != caller && !self.is_approved_for_all(token_owner, caller) {
                 self.log_error(
@@ -316,7 +331,7 @@ mod property_token {
                         ("caller".to_string(), format!("{:?}", caller)),
                         ("owner".to_string(), format!("{:?}", token_owner)),
                     ],
-                );
+                )?;
                 return Err(Error::Unauthorized);
             }
 
@@ -1917,6 +1932,17 @@ mod property_token {
             self.admin
         }
 
+        /// Update the maximum number of recorded errors per caller within one window.
+        #[ink(message)]
+        pub fn set_error_limit(&mut self, limit: u64) -> Result<(), Error> {
+            self.ensure_admin()?;
+            if limit == 0 {
+                return Err(Error::InvalidRequest);
+            }
+            self.error_limit = limit;
+            Ok(())
+        }
+
         /// Internal helper to add a token to an owner
         fn add_token_to_owner(&mut self, to: AccountId, _token_id: TokenId) -> Result<(), Error> {
             let count = self.owner_token_count.get(to).unwrap_or(0);
@@ -2017,54 +2043,104 @@ mod property_token {
             subtotal.saturating_add(buffer)
         }
 
-        /// Log an error for monitoring and debugging
+        fn current_error_rate_state(&self, account: &AccountId, timestamp: u64) -> ErrorRateState {
+            match self.error_rates.get(account) {
+                Some(state)
+                    if timestamp
+                        < state
+                            .window_start
+                            .saturating_add(ERROR_WINDOW_DURATION_MS) =>
+                {
+                    state
+                }
+                _ => ErrorRateState {
+                    count: 0,
+                    window_start: timestamp,
+                },
+            }
+        }
+
+        fn hash_error_entry(
+            log_id: u64,
+            account: &AccountId,
+            error_code: &String,
+            message: &String,
+            timestamp: u64,
+            context: &Vec<(String, String)>,
+            prev_error_hash: &Hash,
+        ) -> Hash {
+            use ink::env::hash::{Blake2x256, CryptoHash};
+            use scale::Encode;
+
+            let data = (
+                log_id,
+                account,
+                error_code,
+                message,
+                timestamp,
+                context,
+                prev_error_hash,
+            );
+            let encoded = data.encode();
+            let mut hash_bytes = [0u8; 32];
+            Blake2x256::hash(&encoded, &mut hash_bytes);
+            Hash::from(hash_bytes)
+        }
+
+        /// Log an error for monitoring and debugging.
         fn log_error(
             &mut self,
             account: AccountId,
             error_code: String,
             message: String,
             context: Vec<(String, String)>,
-        ) {
+        ) -> Result<(), Error> {
             let timestamp = self.env().block_timestamp();
+            let mut rate_state = self.current_error_rate_state(&account, timestamp);
+
+            if rate_state.count >= self.error_limit {
+                return Err(Error::RateLimited);
+            }
+
+            rate_state.count = rate_state.count.saturating_add(1);
+            self.error_rates.insert(&account, &rate_state);
 
             // Update error count for this account and error code
             let key = (account, error_code.clone());
             let current_count = self.error_counts.get(&key).unwrap_or(0);
-            self.error_counts.insert(&key, &(current_count + 1));
-
-            // Update error rate (1 hour window)
-            let window_duration = 3600_000u64; // 1 hour in milliseconds
-            let rate_key = error_code.clone();
-            let (mut count, window_start) =
-                self.error_rates.get(&rate_key).unwrap_or((0, timestamp));
-
-            if timestamp >= window_start + window_duration {
-                // Reset window
-                count = 1;
-                self.error_rates.insert(&rate_key, &(count, timestamp));
-            } else {
-                count += 1;
-                self.error_rates.insert(&rate_key, &(count, window_start));
-            }
-
-            // Add to recent errors (keep last 100)
             let log_id = self.error_log_counter;
-            self.error_log_counter = self.error_log_counter.wrapping_add(1);
-
-            // Only keep last 100 errors (simple circular buffer)
-            if log_id >= 100 {
-                let old_id = log_id.wrapping_sub(100);
-                self.recent_errors.remove(&old_id);
-            }
+            let total_errors = self.account_error_totals.get(&account).unwrap_or(0);
+            let prev_error_hash = self.last_error_hash;
+            let entry_hash = Self::hash_error_entry(
+                log_id,
+                &account,
+                &error_code,
+                &message,
+                timestamp,
+                &context,
+                &prev_error_hash,
+            );
 
             let error_entry = ErrorLogEntry {
+                log_id,
                 error_code: error_code.clone(),
                 message,
                 account,
                 timestamp,
                 context,
+                prev_error_hash,
+                entry_hash,
             };
-            self.recent_errors.insert(&log_id, &error_entry);
+            let slot = log_id % MAX_ERROR_LOG;
+            self.recent_errors.insert(&slot, &error_entry);
+            self.error_counts
+                .insert(&key, &(current_count.saturating_add(1)));
+            self.account_error_totals
+                .insert(&error_entry.account, &(total_errors.saturating_add(1)));
+            self.error_log_counter = self.error_log_counter.wrapping_add(1);
+            self.last_error_hash = error_entry.entry_hash;
+
+            Ok(())
         }
 
         /// Get error count for an account and error code
@@ -2073,20 +2149,30 @@ mod property_token {
             self.error_counts.get(&(account, error_code)).unwrap_or(0)
         }
 
-        /// Get error rate for an error code (errors per hour)
+        /// Get the current sliding-window error rate for an account.
         #[ink(message)]
-        pub fn get_error_rate(&self, error_code: String) -> u64 {
+        pub fn get_error_rate(&self, account: AccountId) -> u64 {
             let timestamp = self.env().block_timestamp();
-            let window_duration = 3600_000u64; // 1 hour
+            self.current_error_rate_state(&account, timestamp).count
+        }
 
-            if let Some((count, window_start)) = self.error_rates.get(&error_code) {
-                if timestamp >= window_start + window_duration {
-                    0 // Window expired
-                } else {
-                    count
-                }
-            } else {
-                0
+        /// Get aggregated error telemetry for a caller.
+        #[ink(message)]
+        pub fn get_error_stats(&self, account: AccountId) -> ErrorStats {
+            let timestamp = self.env().block_timestamp();
+            let rate_state = self.current_error_rate_state(&account, timestamp);
+            let total_errors = self.account_error_totals.get(&account).unwrap_or(0);
+            let is_rate_limited = rate_state.count >= self.error_limit;
+
+            ErrorStats {
+                account,
+                total_errors,
+                window_error_count: rate_state.count,
+                window_start: rate_state.window_start,
+                error_limit: self.error_limit,
+                window_duration_ms: ERROR_WINDOW_DURATION_MS,
+                remaining_before_block: self.error_limit.saturating_sub(rate_state.count),
+                is_rate_limited,
             }
         }
 
@@ -2099,14 +2185,16 @@ mod property_token {
             }
 
             let mut errors = Vec::new();
-            let start_id = if self.error_log_counter > limit as u64 {
-                self.error_log_counter - limit as u64
-            } else {
-                0
-            };
+            let retained = core::cmp::min(self.error_log_counter, MAX_ERROR_LOG);
+            let requested = core::cmp::min(retained, limit as u64);
+            let start_id = self.error_log_counter.saturating_sub(requested);
 
             for i in start_id..self.error_log_counter {
-                if let Some(entry) = self.recent_errors.get(&i) {
+                let slot = i % MAX_ERROR_LOG;
+                if let Some(entry) = self.recent_errors.get(&slot) {
+                    if entry.log_id != i {
+                        continue;
+                    }
                     errors.push(entry);
                 }
             }

--- a/meridian-contracts/contracts/property-token/src/property_token_tests.rs
+++ b/meridian-contracts/contracts/property-token/src/property_token_tests.rs
@@ -369,8 +369,9 @@
         #[ink::test]
         fn test_get_error_rate_nonexistent() {
             let contract = setup_contract();
+            let accounts = test::default_accounts::<DefaultEnvironment>();
 
-            let rate = contract.get_error_rate("NONEXISTENT".to_string());
+            let rate = contract.get_error_rate(accounts.alice);
             assert_eq!(rate, 0);
         }
 
@@ -383,6 +384,122 @@
             test::set_caller::<DefaultEnvironment>(accounts.bob);
             let errors = contract.get_recent_errors(10);
             assert_eq!(errors, Vec::new());
+        }
+
+        #[ink::test]
+        fn test_error_log_cap_respected() {
+            let mut contract = setup_contract();
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .set_error_limit(MAX_ERROR_LOG + 10)
+                .expect("admin should update error limit");
+
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            for token_id in 0..(MAX_ERROR_LOG + 5) {
+                let result = contract.transfer_from(accounts.bob, accounts.charlie, token_id + 1_000);
+                assert_eq!(result, Err(Error::TokenNotFound));
+            }
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            let errors = contract.get_recent_errors((MAX_ERROR_LOG + 10) as u32);
+            assert_eq!(errors.len(), MAX_ERROR_LOG as usize);
+            assert_eq!(errors.first().expect("first retained error").log_id, 5);
+            assert_eq!(
+                errors.last().expect("last retained error").log_id,
+                MAX_ERROR_LOG + 4
+            );
+        }
+
+        #[ink::test]
+        fn test_rate_limit_blocks_abusive_caller() {
+            let mut contract = setup_contract();
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .set_error_limit(3)
+                .expect("admin should update error limit");
+
+            test::set_block_timestamp::<DefaultEnvironment>(1);
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            for _ in 0..3 {
+                let result = contract.transfer_from(accounts.bob, accounts.charlie, 999);
+                assert_eq!(result, Err(Error::TokenNotFound));
+            }
+
+            let stats = contract.get_error_stats(accounts.bob);
+            assert_eq!(stats.total_errors, 3);
+            assert_eq!(stats.window_error_count, 3);
+            assert!(stats.is_rate_limited);
+            assert_eq!(stats.remaining_before_block, 0);
+
+            let blocked = contract.transfer_from(accounts.bob, accounts.charlie, 999);
+            assert_eq!(blocked, Err(Error::RateLimited));
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            let errors = contract.get_recent_errors(10);
+            assert_eq!(errors.len(), 3);
+
+            test::set_block_timestamp::<DefaultEnvironment>(ERROR_WINDOW_DURATION_MS + 10);
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            let after_window = contract.transfer_from(accounts.bob, accounts.charlie, 999);
+            assert_eq!(after_window, Err(Error::TokenNotFound));
+        }
+
+        fn verify_error_chain(entries: &[ErrorLogEntry]) -> bool {
+            let zero_hash = Hash::from([0u8; 32]);
+
+            for (index, entry) in entries.iter().enumerate() {
+                let expected_prev = if index == 0 {
+                    zero_hash
+                } else {
+                    entries[index - 1].entry_hash
+                };
+
+                if entry.prev_error_hash != expected_prev {
+                    return false;
+                }
+
+                let recalculated = PropertyToken::hash_error_entry(
+                    entry.log_id,
+                    &entry.account,
+                    &entry.error_code,
+                    &entry.message,
+                    entry.timestamp,
+                    &entry.context,
+                    &entry.prev_error_hash,
+                );
+                if entry.entry_hash != recalculated {
+                    return false;
+                }
+            }
+
+            true
+        }
+
+        #[ink::test]
+        fn test_error_log_hash_chain_verifies() {
+            let mut contract = setup_contract();
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .set_error_limit(10)
+                .expect("admin should update error limit");
+
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            for timestamp in 1..=3 {
+                test::set_block_timestamp::<DefaultEnvironment>(timestamp);
+                let result = contract.transfer_from(accounts.bob, accounts.charlie, 7_000 + timestamp);
+                assert_eq!(result, Err(Error::TokenNotFound));
+            }
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            let errors = contract.get_recent_errors(10);
+            assert_eq!(errors.len(), 3);
+            assert!(verify_error_chain(&errors));
         }
 
         // Helper: registers a property, verifies compliance, adds bob as operator,

--- a/meridian-contracts/contracts/property-token/src/types.rs
+++ b/meridian-contracts/contracts/property-token/src/types.rs
@@ -75,11 +75,40 @@
     )]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub struct ErrorLogEntry {
+        pub log_id: u64,
         pub error_code: String,
         pub message: String,
         pub account: AccountId,
         pub timestamp: u64,
         pub context: Vec<(String, String)>,
+        pub prev_error_hash: Hash,
+        pub entry_hash: Hash,
+    }
+
+    /// Per-account sliding window state for abusive caller detection.
+    #[derive(
+        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct ErrorRateState {
+        pub count: u64,
+        pub window_start: u64,
+    }
+
+    /// Aggregated error telemetry exposed by the contract.
+    #[derive(
+        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct ErrorStats {
+        pub account: AccountId,
+        pub total_errors: u64,
+        pub window_error_count: u64,
+        pub window_start: u64,
+        pub error_limit: u64,
+        pub window_duration_ms: u64,
+        pub remaining_before_block: u64,
+        pub is_rate_limited: bool,
     }
 
     #[derive(

--- a/meridian-contracts/scripts/verify_property_token_error_chain.py
+++ b/meridian-contracts/scripts/verify_property_token_error_chain.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Verify PropertyToken error log hash chains off-chain.
+
+Usage:
+  python scripts/verify_property_token_error_chain.py errors.json
+  python scripts/verify_property_token_error_chain.py --self-test
+
+The JSON file must contain a top-level array of entries with these fields:
+  - log_id: integer
+  - account: 32-byte hex string
+  - error_code: string
+  - message: string
+  - timestamp: integer
+  - context: [["key", "value"], ...]
+  - prev_error_hash: 32-byte hex string
+  - entry_hash: 32-byte hex string
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from typing import Iterable, Sequence
+
+
+ZERO_HASH = "0x" + ("00" * 32)
+
+
+def compact_encode(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("compact integers must be non-negative")
+    if value < 1 << 6:
+        return bytes([(value << 2) & 0xFF])
+    if value < 1 << 14:
+        encoded = (value << 2) | 0b01
+        return encoded.to_bytes(2, "little")
+    if value < 1 << 30:
+        encoded = (value << 2) | 0b10
+        return encoded.to_bytes(4, "little")
+
+    raw = value.to_bytes((value.bit_length() + 7) // 8, "little")
+    length_descriptor = ((len(raw) - 4) << 2) | 0b11
+    return bytes([length_descriptor]) + raw
+
+
+def encode_u64(value: int) -> bytes:
+    if value < 0 or value > 0xFFFFFFFFFFFFFFFF:
+        raise ValueError(f"u64 out of range: {value}")
+    return value.to_bytes(8, "little")
+
+
+def decode_hex_32(value: str, field_name: str) -> bytes:
+    normalized = value[2:] if value.startswith("0x") else value
+    raw = bytes.fromhex(normalized)
+    if len(raw) != 32:
+        raise ValueError(f"{field_name} must be 32 bytes, got {len(raw)}")
+    return raw
+
+
+def encode_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return compact_encode(len(encoded)) + encoded
+
+
+def encode_context(context: Sequence[Sequence[str]]) -> bytes:
+    output = bytearray(compact_encode(len(context)))
+    for item in context:
+        if len(item) != 2:
+            raise ValueError("each context entry must contain exactly two strings")
+        output.extend(encode_string(str(item[0])))
+        output.extend(encode_string(str(item[1])))
+    return bytes(output)
+
+
+def normalize_hash(value: str) -> str:
+    normalized = value.lower()
+    if not normalized.startswith("0x"):
+        normalized = "0x" + normalized
+    if len(normalized) != 66:
+        raise ValueError(f"invalid 32-byte hash: {value}")
+    return normalized
+
+
+def compute_entry_hash(entry: dict) -> str:
+    payload = b"".join(
+        [
+            encode_u64(int(entry["log_id"])),
+            decode_hex_32(entry["account"], "account"),
+            encode_string(str(entry["error_code"])),
+            encode_string(str(entry["message"])),
+            encode_u64(int(entry["timestamp"])),
+            encode_context(entry.get("context", [])),
+            decode_hex_32(entry["prev_error_hash"], "prev_error_hash"),
+        ]
+    )
+    digest = hashlib.blake2b(payload, digest_size=32).hexdigest()
+    return "0x" + digest
+
+
+def verify_entries(entries: Iterable[dict]) -> bool:
+    previous_hash = ZERO_HASH
+
+    for index, entry in enumerate(entries):
+        actual_prev = normalize_hash(entry["prev_error_hash"])
+        if actual_prev != previous_hash:
+            print(
+                f"chain break at index {index}: expected prev {previous_hash}, got {actual_prev}",
+                file=sys.stderr,
+            )
+            return False
+
+        expected_hash = compute_entry_hash(entry)
+        actual_hash = normalize_hash(entry["entry_hash"])
+        if expected_hash != actual_hash:
+            print(
+                f"hash mismatch at index {index}: expected {expected_hash}, got {actual_hash}",
+                file=sys.stderr,
+            )
+            return False
+
+        previous_hash = actual_hash
+
+    return True
+
+
+def make_self_test_entries() -> list[dict]:
+    account = "0x" + ("11" * 32)
+    entries: list[dict] = []
+    previous_hash = ZERO_HASH
+
+    for log_id, code in enumerate(["TOKEN_NOT_FOUND", "UNAUTHORIZED", "TOKEN_NOT_FOUND"]):
+        entry = {
+            "log_id": log_id,
+            "account": account,
+            "error_code": code,
+            "message": f"sample message {log_id}",
+            "timestamp": log_id + 1,
+            "context": [["operation", "transfer_from"], ["token_id", str(100 + log_id)]],
+            "prev_error_hash": previous_hash,
+        }
+        entry["entry_hash"] = compute_entry_hash(entry)
+        previous_hash = entry["entry_hash"]
+        entries.append(entry)
+
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_file", nargs="?", help="Path to a JSON file with error log entries")
+    parser.add_argument("--self-test", action="store_true", help="Run the built-in verifier smoke test")
+    args = parser.parse_args()
+
+    if args.self_test:
+        ok = verify_entries(make_self_test_entries())
+        print("self-test passed" if ok else "self-test failed")
+        return 0 if ok else 1
+
+    if not args.json_file:
+        parser.error("provide a JSON file or use --self-test")
+
+    with open(args.json_file, "r", encoding="utf-8") as handle:
+        entries = json.load(handle)
+
+    if not isinstance(entries, list):
+        raise ValueError("top-level JSON value must be an array")
+
+    ok = verify_entries(entries)
+    print("verification passed" if ok else "verification failed")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements the missing error monitoring module in `property-token` by turning the existing dead-state fields into enforced behavior.

## Changes
- adds a bounded ring buffer for `recent_errors` with `MAX_ERROR_LOG`
- replaces passive error-rate tracking with per-account sliding-window rate limiting
- blocks abusive callers with `Error::RateLimited` once the configured threshold is exceeded
- adds admin-configurable `set_error_limit(limit)`
- adds `get_error_stats(account)` for caller-level telemetry
- extends `ErrorLogEntry` with `log_id`, `prev_error_hash`, and `entry_hash`
- hash-chains consecutive error log entries for off-chain verification
- adds an off-chain verifier script: `scripts/verify_property_token_error_chain.py`

## Tests
- verifies error log cap is respected
- verifies abusive caller is rate-limited after threshold
- verifies error log hash chain recomputes correctly
- passes: `cargo test -p property-token`

## Acceptance Criteria
- `recent_errors` never exceeds the configured cap
- abusive caller gets rate-limited after threshold
- error log hash-chain verification passes

closes #578 