### PR TITLE
feat: add focus trap, scroll-lock, and auto-close to header mobile menu (#590)

### DIFF
--- a/meridian-web/components/layout/Header.tsx
+++ b/meridian-web/components/layout/Header.tsx
@@ -2,14 +2,33 @@
 
 import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { useActiveSection } from '@/hooks/useActiveSection';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const activeSection = useActiveSection();
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!isMobile && isOpen) {
+      setIsOpen(false);
+    }
+  }, [isMobile, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
 
   const isActive = (id: string) => activeSection === id;
   const baseNavClassName =


### PR DESCRIPTION
## Summary

- Import `useIsMobile()` hook into Header so menu state and breakpoint never disagree
- Auto-close mobile menu when viewport crosses the 768px breakpoint (prevents stale open state on resize)
- Add body scroll lock (`document.body.style.overflow = 'hidden'`) when mobile menu is open, with cleanup on close/unmount
- Radix Dialog already provides focus trap and Esc-to-close (no additional code needed)
- ThemeToggle has consistent `aria-label` across desktop/mobile instances (only one visible at a time)

## Changes

**`meridian-web/components/layout/Header.tsx`**:
- Added `useIsMobile` import from `@/hooks/use-mobile`
- Added `useEffect` to auto-close menu when `isMobile` transitions from `true` to `false`
- Added `useEffect` to lock/unlock body scroll when menu opens/closes

## Testing

- Verified TypeScript compiles (pre-existing errors only, no new errors from this change)
- Desktop: menu trigger hidden, nav + ThemeToggle visible
- Mobile: menu trigger visible, opens Dialog with focus trap, Esc closes, background scroll locked
- Resize from mobile to desktop with menu open: menu auto-closes

Closes #590
