### PR TITLE
fix(property-token): guard code hash upgrades

### DIFF
--- a/meridian-contracts/contracts/property-token/src/lib.rs
+++ b/meridian-contracts/contracts/property-token/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! Property token contract for ownership, compliance, and bridge-enabled operations.
 
-
 use ink::prelude::string::String;
 use ink::storage::Mapping;
 use propchain_traits::*;
@@ -17,6 +16,7 @@ mod property_token {
     const MAX_ERROR_LOG: u64 = 50;
     const ERROR_WINDOW_DURATION_MS: u64 = 3_600_000;
     const DEFAULT_ERROR_LIMIT: u64 = 10;
+    const CODE_HASH_UPGRADE_DELAY_MS: u64 = 48 * 60 * 60 * 1000;
 
     /// Error types for the property token contract
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
@@ -51,6 +51,10 @@ mod property_token {
         AskNotFound,
         InconsistentState,
         RateLimited,
+        InvalidParameters,
+        GovernanceNotSet,
+        UpgradeNotProposed,
+        UpgradeTimelockActive,
     }
 
     /// Property Token contract that maintains compatibility with ERC-721 and ERC-1155
@@ -117,6 +121,10 @@ mod property_token {
         compliance_registry: Option<AccountId>,
         fee_manager: Option<AccountId>,
         tax_records: Mapping<(AccountId, TokenId), TaxRecord>,
+        governance: Option<AccountId>,
+        pending_code_hash: Option<PendingCodeHash>,
+        code_hash_history: Mapping<u64, CodeHashChange>,
+        code_hash_history_count: u64,
 
         // Gas estimation: per-chain overhead and cross-contract buffer (issue #461)
         chain_gas_overhead: Mapping<ChainId, u64>,
@@ -200,6 +208,10 @@ mod property_token {
                 compliance_registry: None,
                 fee_manager: None,
                 tax_records: Mapping::default(),
+                governance: None,
+                pending_code_hash: None,
+                code_hash_history: Mapping::default(),
+                code_hash_history_count: 0,
 
                 chain_gas_overhead: Mapping::default(),
                 cross_contract_gas_buffer_pct: 20,
@@ -217,7 +229,8 @@ mod property_token {
         /// ERC-721: Returns the balance of tokens owned by an account
         #[ink(message)]
         pub fn balance_of(&self, owner: AccountId) -> u32 {
-            self.ensure_non_zero_account(&owner).unwrap_or_else(|_| panic!("Zero address not allowed"));
+            self.ensure_non_zero_account(&owner)
+                .unwrap_or_else(|_| panic!("Zero address not allowed"));
             self.owner_token_count.get(owner).unwrap_or(0)
         }
 
@@ -235,6 +248,7 @@ mod property_token {
             to: AccountId,
             token_id: TokenId,
         ) -> Result<(), Error> {
+            self.ensure_not_paused()?;
             let caller = self.env().caller();
 
             // Collect fee for transfer
@@ -526,18 +540,106 @@ mod property_token {
             Ok(())
         }
 
-        /// Upgrades the contract code to the provided `code_hash`.
-        /// Only the admin can perform this operation.
+        /// Configure the external governance contract that authorizes code upgrades.
         #[ink(message)]
-        pub fn set_code_hash(&mut self, code_hash: Hash) -> Result<(), Error> {
-            let caller = self.env().caller();
-            if caller != self.admin {
-                return Err(Error::Unauthorized);
+        pub fn set_governance(&mut self, governance: AccountId) -> Result<(), Error> {
+            self.ensure_admin()?;
+            Self::ensure_non_zero_account(&governance)?;
+            self.governance = Some(governance);
+            Ok(())
+        }
+
+        /// Return the configured governance contract address, if any.
+        #[ink(message)]
+        pub fn governance(&self) -> Option<AccountId> {
+            self.governance
+        }
+
+        /// Deprecated direct upgrade entry point. Immediate upgrades are disabled.
+        #[ink(message)]
+        pub fn set_code_hash(&mut self, _code_hash: Hash) -> Result<(), Error> {
+            Err(Error::Unauthorized)
+        }
+
+        /// Propose a governance-approved code hash upgrade after the timelock expires.
+        #[ink(message)]
+        pub fn propose_code_hash(&mut self, code_hash: Hash) -> Result<(), Error> {
+            self.ensure_governance()?;
+            let now = self.env().block_timestamp();
+            let executable_at = now.saturating_add(CODE_HASH_UPGRADE_DELAY_MS);
+            self.pending_code_hash = Some(PendingCodeHash {
+                code_hash,
+                proposed_at: now,
+                executable_at,
+                proposer: self.env().caller(),
+            });
+            self.bridge_config.emergency_pause = true;
+            self.env().emit_event(CodeHashProposed {
+                code_hash,
+                executable_at,
+                proposer: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Commit the pending code hash upgrade once the timelock has elapsed.
+        #[ink(message)]
+        pub fn commit_code_hash(&mut self) -> Result<(), Error> {
+            self.ensure_governance()?;
+            let pending = self
+                .pending_code_hash
+                .clone()
+                .ok_or(Error::UpgradeNotProposed)?;
+            let now = self.env().block_timestamp();
+            if now < pending.executable_at {
+                return Err(Error::UpgradeTimelockActive);
             }
             self.env()
-                .set_code_hash(&code_hash)
+                .set_code_hash(&pending.code_hash)
                 .map_err(|_| Error::InvalidRequest)?;
+            let index = self.code_hash_history_count;
+            self.code_hash_history.insert(
+                index,
+                &CodeHashChange {
+                    code_hash: pending.code_hash,
+                    proposed_at: pending.proposed_at,
+                    committed_at: now,
+                    proposer: pending.proposer,
+                    committer: self.env().caller(),
+                },
+            );
+            self.code_hash_history_count = index.saturating_add(1);
+            self.pending_code_hash = None;
+            self.env().emit_event(CodeHashCommitted {
+                code_hash: pending.code_hash,
+                committed_at: now,
+                committer: self.env().caller(),
+            });
             Ok(())
+        }
+
+        /// Return the active pending code hash proposal, if any.
+        #[ink(message)]
+        pub fn pending_code_hash(&self) -> Option<PendingCodeHash> {
+            self.pending_code_hash.clone()
+        }
+
+        /// Return a committed code hash history entry by index.
+        #[ink(message)]
+        pub fn code_hash_history(&self, index: u64) -> Option<CodeHashChange> {
+            self.code_hash_history.get(index)
+        }
+
+        /// Return the number of committed code hash upgrades.
+        #[ink(message)]
+        pub fn code_hash_history_count(&self) -> u64 {
+            self.code_hash_history_count
+        }
+
+        /// Return the fixed upgrade timelock delay in milliseconds.
+        #[ink(message)]
+        pub fn code_hash_upgrade_delay(&self) -> u64 {
+            CODE_HASH_UPGRADE_DELAY_MS
         }
 
         /// Return the total fractional shares issued for a property token.
@@ -625,6 +727,7 @@ mod property_token {
             token_id: TokenId,
             amount: u128,
         ) -> Result<(), Error> {
+            self.ensure_not_paused()?;
             if amount == 0 {
                 return Err(Error::InvalidAmount);
             }
@@ -822,6 +925,7 @@ mod property_token {
             price_per_share: u128,
             amount: u128,
         ) -> Result<(), Error> {
+            self.ensure_not_paused()?;
             if price_per_share == 0 || amount == 0 {
                 return Err(Error::InvalidAmount);
             }
@@ -869,7 +973,11 @@ mod property_token {
                 .insert((seller, token_id), &(bal.saturating_add(ask.amount)));
             self.escrowed_shares.insert((token_id, seller), &0u128);
             self.asks.remove((token_id, seller));
-            self.env().emit_event(AskCancelled { token_id, seller, escrowed_amount: esc });
+            self.env().emit_event(AskCancelled {
+                token_id,
+                seller,
+                escrowed_amount: esc,
+            });
             Ok(())
         }
 
@@ -881,6 +989,7 @@ mod property_token {
             seller: AccountId,
             amount: u128,
         ) -> Result<(), Error> {
+            self.ensure_not_paused()?;
             if amount == 0 {
                 return Err(Error::InvalidAmount);
             }
@@ -998,19 +1107,28 @@ mod property_token {
             let scaling: u128 = 1_000_000_000_000;
             let current_dps = self.dividends_per_share.get(token_id).unwrap_or(0);
             // Retrieve the last checkpoint for this holder.
-            let checkpoint = self.dividend_checkpoint.get((account, token_id)).unwrap_or(0);
+            let checkpoint = self
+                .dividend_checkpoint
+                .get((account, token_id))
+                .unwrap_or(0);
             if current_dps > checkpoint {
                 let bal = self.balances.get((account, token_id)).unwrap_or(0);
                 let delta = current_dps.saturating_sub(checkpoint);
                 // Compute additional credit safely.
                 let add = self.safe_mul_div(bal, delta, scaling);
-                let owed = self.dividend_balance.get((account, token_id)).unwrap_or(0).saturating_add(add);
+                let owed = self
+                    .dividend_balance
+                    .get((account, token_id))
+                    .unwrap_or(0)
+                    .saturating_add(add);
                 self.dividend_balance.insert((account, token_id), &owed);
                 // Update the checkpoint to the latest per‑share value.
-                self.dividend_checkpoint.insert((account, token_id), &current_dps);
+                self.dividend_checkpoint
+                    .insert((account, token_id), &current_dps);
             } else if checkpoint == 0 && current_dps > 0 {
                 // First time the holder sees any dividends.
-                self.dividend_checkpoint.insert((account, token_id), &current_dps);
+                self.dividend_checkpoint
+                    .insert((account, token_id), &current_dps);
             }
             Ok(())
         }
@@ -1057,8 +1175,8 @@ mod property_token {
                 to: caller,
                 timestamp: self.env().block_timestamp(),
                 transaction_hash: {
-                    use scale::Encode;
                     use ink::env::hash::{Blake2x256, CryptoHash};
+                    use scale::Encode;
                     let data = (&caller, token_id);
                     let encoded = data.encode();
                     let mut hash_bytes = [0u8; 32];
@@ -1548,8 +1666,8 @@ mod property_token {
                 to: recipient,
                 timestamp: self.env().block_timestamp(),
                 transaction_hash: {
-                    use scale::Encode;
                     use ink::env::hash::{Blake2x256, CryptoHash};
+                    use scale::Encode;
                     let data = (&recipient, new_token_id);
                     let encoded = data.encode();
                     let mut hash_bytes = [0u8; 32];
@@ -1693,7 +1811,8 @@ mod property_token {
                     request.signatures.clear();
                     // Re-register in the O(1) pending lookup so duplicate-request
                     // guard in initiate_bridge_multisig remains accurate.
-                    self.token_pending_requests.insert(request.token_id, &request_id);
+                    self.token_pending_requests
+                        .insert(request.token_id, &request_id);
                 }
                 RecoveryAction::CancelBridge => {
                     // Mark as cancelled and unlock token
@@ -1986,8 +2105,8 @@ mod property_token {
                 to,
                 timestamp: self.env().block_timestamp(),
                 transaction_hash: {
-                    use scale::Encode;
                     use ink::env::hash::{Blake2x256, CryptoHash};
+                    use scale::Encode;
                     let data = (&from, &to, token_id);
                     let encoded = data.encode();
                     let mut hash_bytes = [0u8; 32];
@@ -2054,10 +2173,7 @@ mod property_token {
         fn current_error_rate_state(&self, account: &AccountId, timestamp: u64) -> ErrorRateState {
             match self.error_rates.get(account) {
                 Some(state)
-                    if timestamp
-                        < state
-                            .window_start
-                            .saturating_add(ERROR_WINDOW_DURATION_MS) =>
+                    if timestamp < state.window_start.saturating_add(ERROR_WINDOW_DURATION_MS) =>
                 {
                     state
                 }
@@ -2254,7 +2370,12 @@ mod property_token {
 
         /// Export a serialized token storage chunk for migration tooling.
         #[ink(message)]
-        fn extract_data_chunk(&self, _chunk_id: u32, _start_index: u32, _count: u32) -> Result<Vec<u8>, Error> {
+        fn extract_data_chunk(
+            &self,
+            _chunk_id: u32,
+            _start_index: u32,
+            _count: u32,
+        ) -> Result<Vec<u8>, Error> {
             self.ensure_admin()?;
             Ok(Vec::new())
         }
@@ -2278,6 +2399,23 @@ mod property_token {
         fn ensure_admin(&self) -> Result<(), Error> {
             if self.env().caller() != self.admin {
                 return Err(Error::Unauthorized);
+            }
+            Ok(())
+        }
+
+        /// Require the caller to be the configured governance contract.
+        fn ensure_governance(&self) -> Result<(), Error> {
+            match self.governance {
+                Some(governance) if self.env().caller() == governance => Ok(()),
+                Some(_) => Err(Error::Unauthorized),
+                None => Err(Error::GovernanceNotSet),
+            }
+        }
+
+        /// Halt user-facing token and share movement while emergency pause is active.
+        fn ensure_not_paused(&self) -> Result<(), Error> {
+            if self.bridge_config.emergency_pause {
+                return Err(Error::BridgePaused);
             }
             Ok(())
         }

--- a/meridian-contracts/contracts/property-token/src/property_token_tests.rs
+++ b/meridian-contracts/contracts/property-token/src/property_token_tests.rs
@@ -628,3 +628,121 @@
                 "duplicate should be blocked after retry recovery"
             );
         }
+
+        #[ink::test]
+        fn admin_direct_code_hash_upgrade_is_blocked() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+
+            let result = contract.set_code_hash(Hash::from([9u8; 32]));
+
+            assert_eq!(result, Err(Error::Unauthorized));
+            assert_eq!(contract.code_hash_history_count(), 0);
+            assert!(contract.pending_code_hash().is_none());
+        }
+
+        #[ink::test]
+        fn governance_proposal_pauses_until_timelocked_commit() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+            let governance = accounts.bob;
+            let new_hash = Hash::from([7u8; 32]);
+
+            contract
+                .set_governance(governance)
+                .expect("admin should configure governance");
+
+            test::set_block_timestamp::<DefaultEnvironment>(1_000);
+            test::set_caller::<DefaultEnvironment>(governance);
+            contract
+                .propose_code_hash(new_hash)
+                .expect("governance should propose code hash");
+
+            let pending = contract
+                .pending_code_hash()
+                .expect("proposal should be stored");
+            assert_eq!(pending.code_hash, new_hash);
+            assert_eq!(
+                pending.executable_at,
+                1_000 + contract.code_hash_upgrade_delay()
+            );
+            assert!(contract.get_bridge_config().emergency_pause);
+            assert_eq!(
+                contract.commit_code_hash(),
+                Err(Error::UpgradeTimelockActive)
+            );
+
+            test::set_block_timestamp::<DefaultEnvironment>(pending.executable_at);
+            assert_eq!(contract.commit_code_hash(), Ok(()));
+            assert!(contract.pending_code_hash().is_none());
+            assert_eq!(contract.code_hash_history_count(), 1);
+
+            let history = contract
+                .code_hash_history(0)
+                .expect("committed upgrade should be recorded");
+            assert_eq!(history.code_hash, new_hash);
+            assert_eq!(history.proposer, governance);
+            assert_eq!(history.committer, governance);
+        }
+
+        #[ink::test]
+        fn non_governance_cannot_propose_or_commit_code_hash() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+
+            assert_eq!(
+                contract.propose_code_hash(Hash::from([3u8; 32])),
+                Err(Error::GovernanceNotSet)
+            );
+
+            contract
+                .set_governance(accounts.bob)
+                .expect("admin should configure governance");
+
+            test::set_caller::<DefaultEnvironment>(accounts.charlie);
+            assert_eq!(
+                contract.propose_code_hash(Hash::from([3u8; 32])),
+                Err(Error::Unauthorized)
+            );
+            assert_eq!(contract.commit_code_hash(), Err(Error::Unauthorized));
+        }
+
+        #[ink::test]
+        fn code_hash_proposal_pause_blocks_token_transfer() {
+            let accounts = test::default_accounts::<DefaultEnvironment>();
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            let mut contract = setup_contract();
+
+            let metadata = PropertyMetadata {
+                location: String::from("Upgrade Guard Ave"),
+                size: 1000,
+                legal_description: String::from("Paused transfer test property"),
+                valuation: 500000,
+                documents_url: String::from("ipfs://upgrade-guard"),
+            };
+            let token_id = contract
+                .register_property_with_token(metadata)
+                .expect("registration should succeed");
+
+            test::set_caller::<DefaultEnvironment>(contract.admin());
+            contract
+                .verify_compliance(token_id, true)
+                .expect("compliance verification should succeed");
+            contract
+                .set_governance(accounts.bob)
+                .expect("admin should configure governance");
+
+            test::set_caller::<DefaultEnvironment>(accounts.bob);
+            contract
+                .propose_code_hash(Hash::from([5u8; 32]))
+                .expect("governance should propose code hash");
+
+            test::set_caller::<DefaultEnvironment>(accounts.alice);
+            assert_eq!(
+                contract.transfer_from(accounts.alice, accounts.charlie, token_id),
+                Err(Error::BridgePaused)
+            );
+        }

--- a/meridian-contracts/contracts/property-token/src/types.rs
+++ b/meridian-contracts/contracts/property-token/src/types.rs
@@ -87,7 +87,13 @@
 
     /// Per-account sliding window state for abusive caller detection.
     #[derive(
-        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        scale::Encode,
+        scale::Decode,
+        ink::storage::traits::StorageLayout,
     )]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub struct ErrorRateState {
@@ -97,7 +103,13 @@
 
     /// Aggregated error telemetry exposed by the contract.
     #[derive(
-        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        scale::Encode,
+        scale::Decode,
+        ink::storage::traits::StorageLayout,
     )]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub struct ErrorStats {
@@ -183,6 +195,29 @@
         pub proceeds: u128,
     }
 
+    #[derive(
+        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct PendingCodeHash {
+        pub code_hash: Hash,
+        pub proposed_at: u64,
+        pub executable_at: u64,
+        pub proposer: AccountId,
+    }
+
+    #[derive(
+        Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct CodeHashChange {
+        pub code_hash: Hash,
+        pub proposed_at: u64,
+        pub committed_at: u64,
+        pub proposer: AccountId,
+        pub committer: AccountId,
+    }
+
     // Events for tracking property token operations
     #[ink(event)]
     pub struct Transfer {
@@ -241,6 +276,24 @@
         pub verified: bool,
         #[ink(topic)]
         pub verifier: AccountId,
+    }
+
+    #[ink(event)]
+    pub struct CodeHashProposed {
+        #[ink(topic)]
+        pub code_hash: Hash,
+        pub executable_at: u64,
+        #[ink(topic)]
+        pub proposer: AccountId,
+    }
+
+    #[ink(event)]
+    pub struct CodeHashCommitted {
+        #[ink(topic)]
+        pub code_hash: Hash,
+        pub committed_at: u64,
+        #[ink(topic)]
+        pub committer: AccountId,
     }
 
     #[ink(event)]
@@ -400,4 +453,3 @@
         pub amount: u128,
         pub price_per_share: u128,
     }
-


### PR DESCRIPTION
### Summary
Implements a governance-gated, paused, timelocked upgrade path for PropertyToken code hash changes.

### Changes
* Disables direct `set_code_hash` upgrades by admin.
* Adds governance configuration via `set_governance`.
* Adds two-step upgrade flow:
  * `propose_code_hash(hash)` stores the pending hash and `executable_at`.
  * `commit_code_hash()` applies the hash only after the timelock.
* Auto-pauses using `bridge_config.emergency_pause` during the upgrade window.
* Blocks token/share movement while paused.
* Emits `CodeHashProposed` and `CodeHashCommitted`.
* Stores committed upgrade records in `code_hash_history`.
* Adds tests for:
  * direct admin upgrade rejection
  * governance proposal and timelock commit
  * pre-delay commit rejection
  * non-governance rejection
  * pause blocking token transfer

### Validation
* Ran `git diff --check` successfully.
* Could not run repo-native Cargo tests because `property-token` and `tests` are not workspace members in `meridian-contracts/Cargo.toml`.
* A temporary workspace compile was blocked by an existing `propchain-traits` ink trait associated-type error at `contracts/traits/src/lib.rs:791`.

### Fixes
* Closes #611.